### PR TITLE
fix: clarify processing level override UX

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,6 +28,10 @@ let package = Package(
         .testTarget(
             name: "VoxProvidersTests",
             dependencies: ["VoxProviders"]
+        ),
+        .testTarget(
+            name: "VoxAppTests",
+            dependencies: ["VoxApp"]
         )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Preferred: `.env.local`
 - Optional: `ELEVENLABS_MODEL_ID`, `ELEVENLABS_LANGUAGE`
 - Optional: `GEMINI_MODEL_ID`, `GEMINI_TEMPERATURE`, `GEMINI_MAX_TOKENS`, `GEMINI_THINKING_LEVEL`
 - Optional: `VOX_CONTEXT_PATH`, `VOX_PROCESSING_LEVEL` (fallback: `VOX_REWRITE_LEVEL`, default: `light`)
+  - `VOX_PROCESSING_LEVEL` overrides menu selection; UI changes won’t persist until removed
 
 Fallback: `~/Documents/Vox/config.json`
 - Auto-generated on first run if missing

--- a/Tests/VoxAppTests/ProcessingLevelOverrideTests.swift
+++ b/Tests/VoxAppTests/ProcessingLevelOverrideTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import VoxApp
+
+final class ProcessingLevelOverrideTests: XCTestCase {
+    func testUsesVoxProcessingLevelWhenPresent() {
+        let env = [
+            "VOX_PROCESSING_LEVEL": "Aggressive",
+            "VOX_REWRITE_LEVEL": "light"
+        ]
+
+        let override = ConfigLoader.processingLevelOverride(from: env)
+
+        XCTAssertEqual(override?.level, .aggressive)
+        XCTAssertEqual(override?.sourceKey, "VOX_PROCESSING_LEVEL")
+    }
+
+    func testFallsBackToVoxRewriteLevel() {
+        let env = ["VOX_REWRITE_LEVEL": "off"]
+
+        let override = ConfigLoader.processingLevelOverride(from: env)
+
+        XCTAssertEqual(override?.level, .off)
+        XCTAssertEqual(override?.sourceKey, "VOX_REWRITE_LEVEL")
+    }
+
+    func testIgnoresInvalidProcessingLevelValue() {
+        let env = [
+            "VOX_PROCESSING_LEVEL": "unknown",
+            "VOX_REWRITE_LEVEL": "light"
+        ]
+
+        let override = ConfigLoader.processingLevelOverride(from: env)
+
+        XCTAssertEqual(override?.level, .light)
+        XCTAssertEqual(override?.sourceKey, "VOX_REWRITE_LEVEL")
+    }
+
+    func testReturnsNilWhenMissing() {
+        let override = ConfigLoader.processingLevelOverride(from: [:])
+
+        XCTAssertNil(override)
+    }
+}

--- a/docs/plan/processing-levels.md
+++ b/docs/plan/processing-levels.md
@@ -22,6 +22,7 @@
 - Config surfaces:
   - `.env.local` → `VOX_PROCESSING_LEVEL` (fallback: `VOX_REWRITE_LEVEL`)
   - `~/Documents/Vox/config.json` → `processingLevel`
+  - Env var wins over menu + config; UI should indicate override
 
 ## Level 1 — Off (Raw Transcript)
 - Pipeline: STT only, no LLM call


### PR DESCRIPTION
## Summary
- detect processing level override from `VOX_PROCESSING_LEVEL`/`VOX_REWRITE_LEVEL`
- show override hint in menu + message on change attempts
- add docs + tests for override parsing

## Testing
- swift test

Closes #30


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Processing level can now be overridden via environment variables, taking precedence over menu selections
  * UI displays "Processing (Locked)" state when override is active
  * Locked state prevents configuration changes from persisting

* **Documentation**
  * Updated configuration guide noting environment variable override behavior

* **Tests**
  * Added test suite for processing level override functionality

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->