### PR TITLE
fix(entitlement): enforce 14-day trial expiration

### DIFF
--- a/Sources/VoxApp/Entitlement/EntitlementCache.swift
+++ b/Sources/VoxApp/Entitlement/EntitlementCache.swift
@@ -17,9 +17,15 @@ struct EntitlementCache: Codable, Equatable, Sendable {
     var isStale: Bool { Date().timeIntervalSince(lastVerified) > Self.staleTTL }
     var isValid: Bool { Date().timeIntervalSince(lastVerified) < Self.validTTL }
 
-    /// Whether the subscription itself is active
+    /// Whether the subscription itself is active.
+    /// For trials, also checks if currentPeriodEnd has passed.
     var isActive: Bool {
-        status == "active"
+        guard status == "active" else { return false }
+        // Trial expiration check (client-side defense in depth)
+        if plan == "trial", let end = currentPeriodEnd, Date() > end {
+            return false
+        }
+        return true
     }
 
     /// Create from gateway response

--- a/apps/gateway/test/lib/entitlements.test.ts
+++ b/apps/gateway/test/lib/entitlements.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// We can't easily test the internal functions (isTrialExpired, getEffectiveStatus)
+// since they're not exported. Instead, we test through the public API.
+
+// Mock Convex client
+vi.mock("../../lib/convex", () => ({
+  getConvexClient: vi.fn(() => ({
+    mutation: vi.fn(),
+  })),
+  api: {
+    users: { getOrCreate: "users:getOrCreate" },
+    entitlements: { getOrCreateTrial: "entitlements:getOrCreateTrial" },
+  },
+}));
+
+import { getEntitlement, requireEntitlement } from "../../lib/entitlements";
+import { getConvexClient } from "../../lib/convex";
+
+describe("lib/entitlements", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("trial expiration", () => {
+    it("returns expired status for trial past currentPeriodEnd", async () => {
+      const mockClient = {
+        mutation: vi
+          .fn()
+          .mockResolvedValueOnce("user_123") // users.getOrCreate
+          .mockResolvedValueOnce({
+            // entitlements.getOrCreateTrial
+            plan: "trial",
+            status: "active",
+            currentPeriodEnd: Date.now() - 3600 * 1000, // 1 hour ago
+          }),
+      };
+      vi.mocked(getConvexClient).mockReturnValue(mockClient as never);
+
+      const result = await getEntitlement("subject_123");
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.status).toBe("expired");
+        expect(result.features).toEqual([]); // No features for expired
+      }
+    });
+
+    it("returns active status for trial with future currentPeriodEnd", async () => {
+      const mockClient = {
+        mutation: vi
+          .fn()
+          .mockResolvedValueOnce("user_123")
+          .mockResolvedValueOnce({
+            plan: "trial",
+            status: "active",
+            currentPeriodEnd: Date.now() + 3600 * 1000, // 1 hour from now
+          }),
+      };
+      vi.mocked(getConvexClient).mockReturnValue(mockClient as never);
+
+      const result = await getEntitlement("subject_123");
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.status).toBe("active");
+        expect(result.features).toContain("stt");
+        expect(result.features).toContain("rewrite");
+      }
+    });
+
+    it("pro plan is not affected by currentPeriodEnd", async () => {
+      const mockClient = {
+        mutation: vi
+          .fn()
+          .mockResolvedValueOnce("user_123")
+          .mockResolvedValueOnce({
+            plan: "pro",
+            status: "active",
+            currentPeriodEnd: Date.now() - 3600 * 1000, // Past date
+          }),
+      };
+      vi.mocked(getConvexClient).mockReturnValue(mockClient as never);
+
+      const result = await getEntitlement("subject_123");
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.status).toBe("active"); // Pro ignores expiration check
+        expect(result.features).toContain("unlimited");
+      }
+    });
+  });
+
+  describe("requireEntitlement", () => {
+    it("returns 403 for expired trial", async () => {
+      const mockClient = {
+        mutation: vi
+          .fn()
+          .mockResolvedValueOnce("user_123")
+          .mockResolvedValueOnce({
+            plan: "trial",
+            status: "active",
+            currentPeriodEnd: Date.now() - 3600 * 1000, // Expired
+          }),
+      };
+      vi.mocked(getConvexClient).mockReturnValue(mockClient as never);
+
+      const result = await requireEntitlement("subject_123", undefined, "stt");
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.statusCode).toBe(403);
+        expect(result.error).toBe("subscription_inactive");
+      }
+    });
+
+    it("allows access for active trial", async () => {
+      const mockClient = {
+        mutation: vi
+          .fn()
+          .mockResolvedValueOnce("user_123")
+          .mockResolvedValueOnce({
+            plan: "trial",
+            status: "active",
+            currentPeriodEnd: Date.now() + 3600 * 1000, // Future
+          }),
+      };
+      vi.mocked(getConvexClient).mockReturnValue(mockClient as never);
+
+      const result = await requireEntitlement("subject_123", undefined, "stt");
+
+      expect(result.ok).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Trials now expire after 14 days from creation
- Gateway returns `status: "expired"` for past-due trials
- Desktop client checks `currentPeriodEnd` in `isActive`
- Migration mutation provided for existing trials

## Changes

| File | Change |
|------|--------|
| `convex/entitlements.ts` | Set `currentPeriodEnd` on trial creation; add migration |
| `lib/entitlements.ts` | Add `isTrialExpired()` and `getEffectiveStatus()` |
| `EntitlementCache.swift` | Check expiration in `isActive` |
| Tests | Coverage for expiration logic in gateway and Swift |

## Migration

After deploy, run:
```bash
npx convex run entitlements:migrateTrialExpirations
```

This sets `currentPeriodEnd = createdAt + 14 days` for existing trials.

## Test plan

- [x] Swift tests pass (11 EntitlementCache tests)
- [x] Gateway tests pass (29 tests)
- [ ] Manual: create new user, verify trial has `currentPeriodEnd`
- [ ] Manual: fast-forward clock or set past date, verify paywall shows

Closes #53

---
🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Trials now automatically expire after 14 days of creation. Users will lose feature access once their trial expires.

* **Tests**
  * Added comprehensive test coverage for trial expiration behavior.

* **Chores**
  * Existing trials have been backfilled with expiration dates for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->