### PR TITLE
fix: payment flow via web checkout bridge

### DIFF
--- a/Sources/VoxApp/Entitlement/PaywallWindowController.swift
+++ b/Sources/VoxApp/Entitlement/PaywallWindowController.swift
@@ -51,7 +51,13 @@ final class PaywallWindowController: NSWindowController {
     }
 
     private func handleUpgrade() {
-        guard let url = GatewayURL.checkout else {
+        guard let token = AuthManager.shared.token else {
+            Diagnostics.error("No auth token for checkout")
+            // Fall back to sign-in flow
+            handleSignIn()
+            return
+        }
+        guard let url = GatewayURL.checkoutPage(token: token) else {
             Diagnostics.error("No gateway URL configured for upgrade")
             return
         }

--- a/apps/web/app/checkout/page.tsx
+++ b/apps/web/app/checkout/page.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import { useEffect, useState, Suspense } from "react";
+import { useSearchParams } from "next/navigation";
+
+type CheckoutStatus = "loading" | "redirecting" | "error";
+
+function CheckoutContent() {
+  const searchParams = useSearchParams();
+  const [status, setStatus] = useState<CheckoutStatus>("loading");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    const token = searchParams.get("token");
+
+    if (!token) {
+      setStatus("error");
+      setErrorMessage("Missing authentication token. Please try again from the Vox app.");
+      return;
+    }
+
+    async function initiateCheckout() {
+      try {
+        setStatus("loading");
+
+        const gatewayUrl = process.env.NEXT_PUBLIC_GATEWAY_URL;
+        if (!gatewayUrl) {
+          throw new Error("Gateway URL not configured");
+        }
+
+        // Call gateway to create Stripe checkout session
+        const response = await fetch(`${gatewayUrl}/api/stripe/checkout`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            successUrl: `${window.location.origin}/checkout/success`,
+            cancelUrl: `${window.location.origin}/checkout?token=${encodeURIComponent(token)}&cancelled=true`,
+          }),
+        });
+
+        if (!response.ok) {
+          const data = await response.json().catch(() => ({}));
+          if (response.status === 401) {
+            throw new Error("Session expired. Please sign in again from the Vox app.");
+          }
+          throw new Error(data.error || `Checkout failed (${response.status})`);
+        }
+
+        const { checkoutUrl } = await response.json();
+
+        if (!checkoutUrl) {
+          throw new Error("No checkout URL received");
+        }
+
+        setStatus("redirecting");
+        window.location.href = checkoutUrl;
+      } catch (err) {
+        setStatus("error");
+        setErrorMessage(err instanceof Error ? err.message : "Something went wrong");
+      }
+    }
+
+    // Check if returning from cancelled checkout
+    const cancelled = searchParams.get("cancelled");
+    if (cancelled === "true") {
+      setStatus("error");
+      setErrorMessage("Checkout was cancelled. Click below to try again.");
+      return;
+    }
+
+    initiateCheckout();
+  }, [searchParams]);
+
+  if (status === "loading") {
+    return (
+      <CheckoutCard>
+        <div className="spinner" />
+        <h1>Preparing checkout...</h1>
+        <p>Please wait while we set up your subscription.</p>
+      </CheckoutCard>
+    );
+  }
+
+  if (status === "redirecting") {
+    return (
+      <CheckoutCard>
+        <div className="spinner" />
+        <h1>Redirecting to payment...</h1>
+        <p>You&apos;ll be redirected to Stripe to complete your purchase.</p>
+      </CheckoutCard>
+    );
+  }
+
+  const token = searchParams.get("token");
+
+  return (
+    <CheckoutCard error>
+      <h1>Checkout Error</h1>
+      <p>{errorMessage}</p>
+      {token && (
+        <button
+          onClick={() => {
+            window.location.href = `/checkout?token=${encodeURIComponent(token)}`;
+          }}
+        >
+          Try Again
+        </button>
+      )}
+      <p className="hint">
+        Having trouble? Contact{" "}
+        <a href="mailto:support@mistystep.io">support@mistystep.io</a>
+      </p>
+    </CheckoutCard>
+  );
+}
+
+function CheckoutCard({
+  children,
+  error,
+}: {
+  children: React.ReactNode;
+  error?: boolean;
+}) {
+  return (
+    <>
+      <div className={`checkout-card ${error ? "error" : ""}`}>{children}</div>
+      <style jsx>{`
+        .checkout-card {
+          background: #fff;
+          border-radius: 12px;
+          padding: 2.5rem;
+          max-width: 420px;
+          width: 100%;
+          text-align: center;
+        }
+        .checkout-card.error {
+          border: 2px solid #dc3545;
+        }
+        .checkout-card :global(h1) {
+          margin: 1rem 0 0.5rem;
+          font-size: 1.5rem;
+          color: #1a1a2e;
+        }
+        .checkout-card.error :global(h1) {
+          color: #dc3545;
+        }
+        .checkout-card :global(p) {
+          margin: 0.5rem 0;
+          color: #666;
+          font-size: 0.95rem;
+        }
+        .checkout-card :global(.hint) {
+          margin-top: 1.5rem;
+          font-size: 0.85rem;
+          color: #999;
+        }
+        .checkout-card :global(.hint a) {
+          color: #666;
+        }
+        .checkout-card :global(button) {
+          margin-top: 1.5rem;
+          padding: 0.75rem 2rem;
+          background: #1a1a2e;
+          color: #fff;
+          border: none;
+          border-radius: 6px;
+          cursor: pointer;
+          font-size: 1rem;
+        }
+        .checkout-card :global(button:hover) {
+          background: #16213e;
+        }
+        .checkout-card :global(.spinner) {
+          width: 48px;
+          height: 48px;
+          border: 3px solid #e0e0e0;
+          border-top-color: #1a1a2e;
+          border-radius: 50%;
+          margin: 0 auto;
+          animation: spin 1s linear infinite;
+        }
+        @keyframes spin {
+          to {
+            transform: rotate(360deg);
+          }
+        }
+      `}</style>
+    </>
+  );
+}
+
+function CheckoutContainer({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <div className="checkout-container">{children}</div>
+      <style jsx>{`
+        .checkout-container {
+          min-height: 100vh;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+          padding: 1rem;
+        }
+      `}</style>
+    </>
+  );
+}
+
+export default function CheckoutPage() {
+  return (
+    <CheckoutContainer>
+      <Suspense
+        fallback={
+          <CheckoutCard>
+            <div className="spinner" />
+            <h1>Loading...</h1>
+          </CheckoutCard>
+        }
+      >
+        <CheckoutContent />
+      </Suspense>
+    </CheckoutContainer>
+  );
+}

--- a/apps/web/app/checkout/success/page.tsx
+++ b/apps/web/app/checkout/success/page.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export default function CheckoutSuccessPage() {
+  const [deepLinkAttempted, setDeepLinkAttempted] = useState(false);
+
+  useEffect(() => {
+    // Attempt to open the app via deep link
+    const timer = setTimeout(() => {
+      window.location.href = "vox://payment-success";
+      setDeepLinkAttempted(true);
+    }, 1000);
+
+    return () => clearTimeout(timer);
+  }, []);
+
+  return (
+    <>
+      <div className="success-container">
+        <div className="success-card">
+          <div className="checkmark">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M20 6L9 17l-5-5" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+          </div>
+          <h1>Payment Successful!</h1>
+          <p>Thank you for subscribing to Vox Pro.</p>
+          <p className="redirect-text">
+            {deepLinkAttempted
+              ? "Opening Vox..."
+              : "Redirecting you back to the app..."}
+          </p>
+          <button onClick={() => (window.location.href = "vox://payment-success")}>
+            Open Vox
+          </button>
+          <p className="hint">
+            If the app doesn&apos;t open automatically, click the button above.
+          </p>
+        </div>
+      </div>
+      <style jsx>{`
+        .success-container {
+          min-height: 100vh;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+          padding: 1rem;
+        }
+        .success-card {
+          background: #fff;
+          border-radius: 12px;
+          padding: 2.5rem;
+          max-width: 420px;
+          width: 100%;
+          text-align: center;
+        }
+        .checkmark {
+          width: 64px;
+          height: 64px;
+          background: #10b981;
+          border-radius: 50%;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          margin: 0 auto 1.5rem;
+        }
+        .checkmark svg {
+          width: 32px;
+          height: 32px;
+          color: #fff;
+        }
+        h1 {
+          margin: 0 0 0.5rem;
+          font-size: 1.5rem;
+          color: #1a1a2e;
+        }
+        p {
+          margin: 0.5rem 0;
+          color: #666;
+          font-size: 0.95rem;
+        }
+        .redirect-text {
+          color: #10b981;
+          font-weight: 500;
+        }
+        button {
+          margin-top: 1.5rem;
+          padding: 0.75rem 2rem;
+          background: #1a1a2e;
+          color: #fff;
+          border: none;
+          border-radius: 6px;
+          cursor: pointer;
+          font-size: 1rem;
+        }
+        button:hover {
+          background: #16213e;
+        }
+        .hint {
+          margin-top: 1rem;
+          font-size: 0.85rem;
+          color: #999;
+        }
+      `}</style>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `/checkout` and `/checkout/success` pages to web app as checkout bridge
- Desktop app now opens web page with auth token in URL
- Web page calls gateway API to create Stripe checkout session, redirects to Stripe
- Success page triggers `vox://payment-success` deep link to reopen app
- Add deep link handler in AppDelegate for payment success

## Changes
- `apps/web/app/checkout/page.tsx` - New checkout bridge page
- `apps/web/app/checkout/success/page.tsx` - Success page with deep link
- `Sources/VoxApp/GatewayClient.swift` - Add web URL support, `checkoutPage(token:)`
- `Sources/VoxApp/Entitlement/PaywallWindowController.swift` - Pass token via URL
- `Sources/VoxApp/AppDelegate.swift` - Handle `vox://payment-success` deep link

## Test plan
- [ ] Sign in via desktop app
- [ ] Click "Upgrade" on paywall
- [ ] Verify browser opens `/checkout?token=...`
- [ ] Complete Stripe checkout
- [ ] Verify redirect to `/checkout/success`
- [ ] Verify deep link opens app and closes paywall

Fixes #52

---
Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a checkout page for secure payment processing with token-based authentication.
  * Added a payment success confirmation page that automatically redirects users back to the mobile app.
  * Enhanced deep link handling for authentication and payment success flows.

* **Bug Fixes**
  * Improved error handling and sign-in fallback during payment operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->