### PR TITLE
feat: add pricing section to marketing site

### DIFF
--- a/apps/web/app/checkout/page.tsx
+++ b/apps/web/app/checkout/page.tsx
@@ -11,13 +11,16 @@ function CheckoutContent() {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   useEffect(() => {
-    const token = searchParams.get("token");
+    const tokenParam = searchParams.get("token");
 
-    if (!token) {
+    if (!tokenParam) {
       setStatus("error");
       setErrorMessage("Missing authentication token. Please try again from the Vox app.");
       return;
     }
+
+    // Capture non-null token for use in async function
+    const token = tokenParam;
 
     async function initiateCheckout() {
       try {

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -284,6 +284,118 @@ h1 {
   line-height: 1.6;
 }
 
+/* Pricing */
+.pricing {
+  padding: 80px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.pricing .container {
+  text-align: center;
+}
+
+.pricing h2 {
+  font-size: 36px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin-bottom: 12px;
+}
+
+.pricing-subtitle {
+  font-size: 16px;
+  color: var(--muted);
+  margin-bottom: 48px;
+}
+
+.pricing-cards {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 24px;
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.pricing-card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 32px;
+  text-align: left;
+  position: relative;
+}
+
+.pricing-card.featured {
+  border-color: var(--accent);
+  border-width: 2px;
+}
+
+.pricing-badge {
+  position: absolute;
+  top: -12px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--accent);
+  color: var(--bg);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 4px 12px;
+  border-radius: 20px;
+}
+
+.pricing-card h3 {
+  font-size: 20px;
+  font-weight: 600;
+  margin-bottom: 16px;
+}
+
+.price {
+  margin-bottom: 24px;
+}
+
+.price-amount {
+  font-size: 40px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.price-period {
+  font-size: 14px;
+  color: var(--muted);
+  margin-left: 4px;
+}
+
+.pricing-features {
+  list-style: none;
+  margin-bottom: 24px;
+}
+
+.pricing-features li {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 14px;
+  color: var(--fg);
+  padding: 8px 0;
+}
+
+.pricing-features svg {
+  width: 16px;
+  height: 16px;
+  color: var(--muted);
+  flex-shrink: 0;
+}
+
+.pricing-card .cta {
+  width: 100%;
+}
+
+nav {
+  display: flex;
+  gap: 20px;
+}
+
 /* Footer */
 footer {
   padding: 32px 0;
@@ -326,6 +438,10 @@ footer a:hover {
   .features .container {
     grid-template-columns: 1fr;
     gap: 24px;
+  }
+
+  .pricing-cards {
+    grid-template-columns: 1fr;
   }
 }
 

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -152,6 +152,7 @@ export default function Page() {
           <div className="header-right">
             <ThemeToggle />
             <nav>
+              <a href="#pricing">Pricing</a>
               <a href="mailto:hello@mistystep.io">Contact</a>
             </nav>
           </div>
@@ -235,6 +236,72 @@ export default function Page() {
               Text appears at your cursor in under a second. No plugins, no app
               switching.
             </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="pricing" id="pricing">
+        <div className="container">
+          <h2>Simple, transparent pricing</h2>
+          <p className="pricing-subtitle">
+            Start with a free trial. Upgrade when you&apos;re ready.
+          </p>
+          <div className="pricing-cards">
+            <div className="pricing-card">
+              <h3>Trial</h3>
+              <div className="price">
+                <span className="price-amount">Free</span>
+                <span className="price-period">for 14 days</span>
+              </div>
+              <ul className="pricing-features">
+                <li>
+                  <CheckIcon />
+                  Unlimited dictation
+                </li>
+                <li>
+                  <CheckIcon />
+                  AI text cleanup
+                </li>
+                <li>
+                  <CheckIcon />
+                  Instant paste
+                </li>
+              </ul>
+              <a
+                href={process.env.NEXT_PUBLIC_DOWNLOAD_URL || "#"}
+                className="cta primary"
+              >
+                Start free trial
+              </a>
+            </div>
+            <div className="pricing-card featured">
+              <div className="pricing-badge">Most Popular</div>
+              <h3>Pro</h3>
+              <div className="price">
+                <span className="price-amount">$9</span>
+                <span className="price-period">/month</span>
+              </div>
+              <ul className="pricing-features">
+                <li>
+                  <CheckIcon />
+                  Everything in Trial
+                </li>
+                <li>
+                  <CheckIcon />
+                  Unlimited usage
+                </li>
+                <li>
+                  <CheckIcon />
+                  Priority support
+                </li>
+              </ul>
+              <a
+                href={process.env.NEXT_PUBLIC_DOWNLOAD_URL || "#"}
+                className="cta primary"
+              >
+                Get Vox Pro
+              </a>
+            </div>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- Add pricing section to marketing site homepage with Trial and Pro tiers
- Add Pricing link to navigation
- Fix TypeScript type narrowing in checkout page

## Changes
- `apps/web/app/page.tsx` - Add pricing section with Trial/Pro cards
- `apps/web/app/globals.css` - Pricing section styles (responsive)
- `apps/web/app/checkout/page.tsx` - Fix token type narrowing

## Pricing shown
- **Trial**: Free for 14 days (matches code in `apps/gateway/convex/entitlements.ts`)
- **Pro**: $9/month (placeholder - update when Stripe product is configured)

## Next steps
- [ ] Create Stripe product and price in Dashboard
- [ ] Set `STRIPE_PRICE_ID` env var
- [ ] Update `$9` placeholder if price differs

## Test plan
- [ ] View homepage, scroll to pricing section
- [ ] Verify responsive layout on mobile
- [ ] Click "Start free trial" → should link to download

Partially addresses #56

---
Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Pricing section to the homepage displaying trial and pro plan tiers
  * Pricing cards showcase plan features and pricing information with dedicated call-to-action buttons
  * "Most Popular" badge highlights the recommended plan option
  * Responsive pricing layout adapts to smaller screens

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->