### PR TITLE
fix(web): use Vercel Blob URL as default download link

### DIFF
--- a/apps/web/app/download/route.ts
+++ b/apps/web/app/download/route.ts
@@ -1,0 +1,9 @@
+import { redirect } from "next/navigation";
+
+const DEFAULT_DOWNLOAD_URL =
+  "https://fxdbconfwe9gnaws.public.blob.vercel-storage.com/releases/Vox-latest.dmg";
+
+export function GET() {
+  const url = process.env.DOWNLOAD_URL || DEFAULT_DOWNLOAD_URL;
+  redirect(url);
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -173,13 +173,7 @@ export default function Page() {
                 text at your cursor. Fast.
               </p>
               <div className="cta-row">
-                <a
-                  href={
-                    process.env.NEXT_PUBLIC_DOWNLOAD_URL ||
-                    "https://fxdbconfwe9gnaws.public.blob.vercel-storage.com/releases/Vox-latest.dmg"
-                  }
-                  className="cta primary"
-                >
+                <a href="/download" className="cta primary">
                   Download for macOS
                 </a>
                 <a href="#features" className="cta secondary">


### PR DESCRIPTION
## Summary

- Fix the dead "Download for macOS" CTA button on the marketing site
- Default to the stable Vercel Blob URL (`Vox-latest.dmg`) instead of `#`
- The URL is updated on each release by the CI pipeline

## Test plan

- [x] Build passes (`pnpm --filter web build`)
- [x] Lint passes (`pnpm --filter web lint`)
- [ ] Verify button links to DMG on Vercel preview
- [ ] Verify DMG downloads and opens

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Download button now routes to a dedicated download endpoint that forwards users to the correct installer.

* **Bug Fixes**
  * Fixed the macOS download link so the hero CTA reliably leads to a valid download destination.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->