### PR TITLE
fix: resolve compiler warnings

### DIFF
--- a/Sources/VoxApp/Settings/PreferencesStore.swift
+++ b/Sources/VoxApp/Settings/PreferencesStore.swift
@@ -37,7 +37,7 @@ public final class PreferencesStore: ObservableObject {
             }
             return KeychainHelper.load(.elevenLabsAPIKey) ?? ""
         }
-        set { _ = KeychainHelper.save(newValue, for: .elevenLabsAPIKey); objectWillChange.send() }
+        set { KeychainHelper.save(newValue, for: .elevenLabsAPIKey); objectWillChange.send() }
     }
 
     public var openRouterAPIKey: String {
@@ -47,7 +47,7 @@ public final class PreferencesStore: ObservableObject {
             }
             return KeychainHelper.load(.openRouterAPIKey) ?? ""
         }
-        set { _ = KeychainHelper.save(newValue, for: .openRouterAPIKey); objectWillChange.send() }
+        set { KeychainHelper.save(newValue, for: .openRouterAPIKey); objectWillChange.send() }
     }
 
     public var deepgramAPIKey: String {
@@ -57,7 +57,7 @@ public final class PreferencesStore: ObservableObject {
             }
             return KeychainHelper.load(.deepgramAPIKey) ?? ""
         }
-        set { _ = KeychainHelper.save(newValue, for: .deepgramAPIKey); objectWillChange.send() }
+        set { KeychainHelper.save(newValue, for: .deepgramAPIKey); objectWillChange.send() }
     }
 
     public var openAIAPIKey: String {
@@ -67,6 +67,6 @@ public final class PreferencesStore: ObservableObject {
             }
             return KeychainHelper.load(.openAIAPIKey) ?? ""
         }
-        set { _ = KeychainHelper.save(newValue, for: .openAIAPIKey); objectWillChange.send() }
+        set { KeychainHelper.save(newValue, for: .openAIAPIKey); objectWillChange.send() }
     }
 }

--- a/Sources/VoxMac/KeychainHelper.swift
+++ b/Sources/VoxMac/KeychainHelper.swift
@@ -11,6 +11,7 @@ public enum KeychainHelper {
         case openAIAPIKey = "com.vox.openai.apikey"
     }
 
+    @discardableResult
     public static func save(_ value: String, for key: Key) -> Bool {
         delete(key)
         let data = value.data(using: .utf8)!


### PR DESCRIPTION
## Summary
- Use `Unmanaged<CFString>` for CoreAudio property queries in `AudioDeviceManager` to avoid forming `UnsafeMutableRawPointer` to ARC-managed CFString objects
- Silence unused result warnings on `KeychainHelper.save()` calls in `PreferencesStore`

## Test plan
- [x] `swift build` — zero warnings
- [x] `swift test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved memory management safety for audio device property retrieval
  * Enhanced code quality for keychain operations handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->