### PR TITLE
ci: integrate Cerberus AI code review council

### DIFF
--- a/.github/workflows/cerberus.yml
+++ b/.github/workflows/cerberus.yml
@@ -1,0 +1,46 @@
+# Cerberus AI Code Review Council
+# https://github.com/misty-step/cerberus
+name: Cerberus Council
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: cerberus-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    name: "${{ matrix.reviewer }}"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - { reviewer: APOLLO, perspective: correctness }
+          - { reviewer: ATHENA, perspective: architecture }
+          - { reviewer: SENTINEL, perspective: security }
+          - { reviewer: VULCAN, perspective: performance }
+          - { reviewer: ARTEMIS, perspective: maintainability }
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+      - uses: misty-step/cerberus@v1
+        with:
+          perspective: ${{ matrix.perspective }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          kimi-api-key: ${{ secrets.MOONSHOT_API_KEY }}
+
+  verdict:
+    name: "Council Verdict"
+    needs: review
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: misty-step/cerberus/verdict@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds Cerberus multi-agent AI code review to this repo.

Every PR will be reviewed by 5 AI perspectives:
- **APOLLO** (correctness) — logic, edge cases, bugs
- **ATHENA** (architecture) — design, patterns, structure
- **SENTINEL** (security) — vulnerabilities, injection, auth
- **VULCAN** (performance) — efficiency, scaling, resources
- **ARTEMIS** (maintainability) — readability, testing, docs

Council aggregates verdicts into PASS/WARN/FAIL.

Ref: https://github.com/misty-step/cerberus

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented a new automated code review system that evaluates pull requests across five dimensions: correctness, architecture, security, performance, and maintainability. Reviews run in parallel with a consolidated verdict.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->