### PR TITLE
fix(audio): prevent crash in opus encode path

### DIFF
--- a/Tests/VoxAppTests/DictationPipelineConcurrencyTests.swift
+++ b/Tests/VoxAppTests/DictationPipelineConcurrencyTests.swift
@@ -34,12 +34,18 @@ private final class NoopPaster: TextPaster {
 }
 
 private func makeTestCAF() throws -> URL {
+    let sampleRate = 16_000.0
+    let durationMilliseconds = 200.0
+    let frameCount = AVAudioFrameCount(sampleRate * (durationMilliseconds / 1_000.0))
     let url = FileManager.default.temporaryDirectory
         .appendingPathComponent("pipeline-\(UUID().uuidString).caf")
-    let format = AVAudioFormat(standardFormatWithSampleRate: 16_000, channels: 1)!
+    guard let format = AVAudioFormat(standardFormatWithSampleRate: sampleRate, channels: 1) else {
+        throw VoxError.internalError("Failed to create test audio format")
+    }
     let file = try AVAudioFile(forWriting: url, settings: format.settings)
-    let frameCount = AVAudioFrameCount(16_000 / 5) // 200ms
-    let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount)!
+    guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount) else {
+        throw VoxError.internalError("Failed to create test audio buffer")
+    }
     buffer.frameLength = frameCount
     if let channelData = buffer.floatChannelData {
         for index in 0..<Int(frameCount) {


### PR DESCRIPTION
## Summary
- prevent submit-time crash in Opus conversion path on macOS
- guard against non-PCM Opus output formats before allocating `AVAudioPCMBuffer`
- keep existing safe fallback behavior (`encodeForUpload` returns original CAF when Opus conversion is unavailable)
- strengthen pipeline concurrency test to use a real CAF fixture so encoder path is exercised

## Root Cause
`AVAudioPCMBuffer.init(pcmFormat:frameCapacity:)` was called with an Opus format (`commonFormat == .otherFormat`), which triggers an Objective-C exception (`NSException`) that bypasses Swift `do/catch` and aborts the process.

## Changes
- `Sources/VoxMac/AudioEncoder.swift`
  - add guard for `outputFormat.commonFormat != .otherFormat`
  - throw `VoxError.internalError` early so upstream fallback can run
- `Tests/VoxAppTests/DictationPipelineConcurrencyTests.swift`
  - generate a valid CAF test file via `AVAudioFile`
  - run pipeline against real audio and clean up afterward

## Verification
- `swift test -Xswiftc -warnings-as-errors`
- `git push` pre-push hook (`swift build -Xswiftc -warnings-as-errors`) passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio encoding stability by validating PCM conversion, preventing empty outputs, and ensuring safe fallback and cleanup on error.

* **Tests**
  * Enhanced test setup with a reusable CAF audio generator and secure cleanup for more reliable audio tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->