### PR TITLE
refactor: add SessionExtension seam for wrapper integrations

### DIFF
--- a/Sources/VoxCore/SessionExtension.swift
+++ b/Sources/VoxCore/SessionExtension.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+public struct DictationUsageEvent: Sendable, Equatable {
+    public let recordingDuration: TimeInterval
+    public let outputCharacterCount: Int
+    public let processingLevel: ProcessingLevel
+
+    public init(
+        recordingDuration: TimeInterval,
+        outputCharacterCount: Int,
+        processingLevel: ProcessingLevel
+    ) {
+        self.recordingDuration = recordingDuration
+        self.outputCharacterCount = max(outputCharacterCount, 0)
+        self.processingLevel = processingLevel
+    }
+}
+
+@MainActor
+public protocol SessionExtension: AnyObject {
+    func authorizeRecordingStart() async throws
+    func didCompleteDictation(event: DictationUsageEvent) async
+    func didFailDictation(reason: String) async
+}
+
+extension SessionExtension {
+    public func authorizeRecordingStart() async throws {}
+    public func didCompleteDictation(event: DictationUsageEvent) async {}
+    public func didFailDictation(reason: String) async {}
+}
+
+@MainActor
+public final class NoopSessionExtension: SessionExtension {
+    public init() {}
+}

--- a/Tests/VoxCoreTests/SessionExtensionTests.swift
+++ b/Tests/VoxCoreTests/SessionExtensionTests.swift
@@ -1,0 +1,36 @@
+import Testing
+import VoxCore
+
+@MainActor
+private final class DefaultSessionExtension: SessionExtension {}
+
+@Suite("SessionExtension")
+struct SessionExtensionTests {
+    @Test("Usage event clamps negative output count")
+    func usageEventClampsNegativeOutput() {
+        let event = DictationUsageEvent(
+            recordingDuration: 1.25,
+            outputCharacterCount: -12,
+            processingLevel: .light
+        )
+
+        #expect(event.recordingDuration == 1.25)
+        #expect(event.outputCharacterCount == 0)
+        #expect(event.processingLevel == .light)
+    }
+
+    @Test("Default protocol methods are no-op")
+    @MainActor
+    func defaultMethodsAreNoop() async throws {
+        let sessionExtension = DefaultSessionExtension()
+        try await sessionExtension.authorizeRecordingStart()
+        await sessionExtension.didCompleteDictation(
+            event: DictationUsageEvent(
+                recordingDuration: 0,
+                outputCharacterCount: 0,
+                processingLevel: .off
+            )
+        )
+        await sessionExtension.didFailDictation(reason: "ignored")
+    }
+}

--- a/docs/adr/0002-session-extension-seam.md
+++ b/docs/adr/0002-session-extension-seam.md
@@ -1,0 +1,58 @@
+# ADR-0002: Session Extension Seam for Wrappers
+
+## Status
+
+Accepted
+
+## Context
+
+`VoxSession` owns the recording lifecycle and currently hard-codes all side effects in one flow. External wrappers need to add authorization, metering, and sync behavior without forking this orchestration code.
+
+Without an explicit seam, wrappers must either:
+- patch `VoxSession` directly (high drift risk), or
+- duplicate the session flow (behavior divergence risk).
+
+We need a small interface that keeps session internals private while allowing wrapper-specific policies.
+
+## Decision
+
+Introduce a session-level extension contract in `VoxCore`:
+- `SessionExtension` protocol with three async hooks:
+  - `authorizeRecordingStart()`
+  - `didCompleteDictation(event:)`
+  - `didFailDictation(reason:)`
+- `DictationUsageEvent` payload with only stable metadata:
+  - recording duration
+  - output character count
+  - processing level
+- `NoopSessionExtension` default implementation.
+
+`VoxSession` now accepts an optional `sessionExtension` dependency and invokes hooks from the existing lifecycle.
+
+## Consequences
+
+### Positive
+
+- Wrappers can add auth/billing/sync behavior without replacing `VoxSession`.
+- Session internals stay hidden behind one small interface.
+- Open source default behavior remains unchanged.
+
+### Negative
+
+- `VoxSession` has one more injected dependency.
+- Hook ordering is now a contract that must remain stable across refactors.
+
+### Neutral
+
+- No user-visible settings or UI changes.
+- No changes to STT provider chaining or rewrite behavior.
+
+## Alternatives Considered
+
+### Alternative 1: Subclass `VoxSession`
+
+Rejected because lifecycle logic is not designed for inheritance; override points would leak internals and increase coupling.
+
+### Alternative 2: Add dedicated auth/billing/sync modules now
+
+Rejected because it introduces product-specific surface area into OSS before concrete requirements exist.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -52,3 +52,4 @@ Examples:
 | ADR | Title | Status |
 |-----|-------|--------|
 | [0001](0001-simplicity-first-design.md) | Simplicity-First Design | Accepted |
+| [0002](0002-session-extension-seam.md) | Session Extension Seam for Wrappers | Accepted |


### PR DESCRIPTION
## Summary
- add `SessionExtension` and `DictationUsageEvent` in `VoxCore` as a small wrapper seam for authorize/success/failure hooks
- wire `VoxSession` to invoke extension hooks and add testable injections for microphone access + error presentation
- add focused `VoxSession` behavior tests for authorize, microphone denial, cancellation, and success usage events
- document the seam in `docs/ARCHITECTURE.md` and add ADR `0002-session-extension-seam.md`

## Validation
- `swift build -Xswiftc -warnings-as-errors`
- `swift test -Xswiftc -warnings-as-errors`

Closes #107


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added extensibility hooks for session behavior customization, enabling custom authorization, completion, and failure handling.
  * Enhanced microphone permission flow with improved error signaling and presentation.

* **Documentation**
  * Updated architecture documentation to reflect new integration points and wrapper patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->