### PR TITLE
feat(stt): add hedged STT provider with staggered racing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,29 +33,23 @@ VoxAppKit was extracted from VoxApp so tests can import it — SwiftPM executabl
 
 ### STT Resilience Chain
 
-Providers are wrapped in composable decorators, with dynamic routing via provider health:
+Providers are wrapped in composable decorators, with default routing via staggered hedging:
 
 ```text
                          ConcurrencyLimit(8 default)
                                    │
                                    ▼
-                            FallbackSTTProvider
-                              primary │ fallback
-                                      └── Apple Speech (on-device, always available fallback)
-                             
-                              HealthAwareSTTProvider(window: 20 attempts)
-                                         │
-                           dynamic cloud-provider ordering per request
-                                         │
-        ElevenLabs(Timeout+Retry) • Deepgram(Timeout+Retry) • Whisper(Timeout+Retry)
+                             HedgedSTTProvider
+                                        │
+      Apple Speech(0s) • ElevenLabs(0s Timeout+Retry) • Deepgram(5s Timeout+Retry) • Whisper(10s Timeout+Retry)
 ```
 
 - **TimeoutSTTProvider**: dynamic deadline — `baseTimeout + fileSizeMB * secondsPerMB`
 - **RetryingSTTProvider**: exponential backoff + jitter on `STTError.isRetryable` errors
-- **HealthAwareSTTProvider**: rolling health metrics (`successRate`, `averageLatency`, transient/permanent failures) drive provider ordering
+- **HedgedSTTProvider**: launches providers with stagger delays and returns first success
 - **ConcurrencyLimitedSTTProvider**: bounds in-flight STT transcribes and queues overflow
-- **FallbackSTTProvider**: catches `STTError.isFallbackEligible`, invokes callback, tries next
-- Retry/fallback logic treats non-STTError failures as fallback-eligible network/transient failures
+- **HealthAwareSTTProvider / FallbackSTTProvider**: retained for alternate routing strategies and tests
+- Hedge/fallback logic treats non-STTError failures as fallback-eligible network/transient failures
 - `CancellationError` must propagate cleanly through all decorators
 
 ### Data Flow
@@ -68,11 +62,11 @@ Option+Space → AudioRecorder (16kHz/16-bit mono CAF) → STT chain → optiona
 
 ## Key Patterns
 
-**Decorator composition**: Add cross-cutting concerns (timeout, retry, health-aware routing, fallback) by wrapping `STTProvider`. Never add special-case branches inside providers.
+**Decorator composition**: Add cross-cutting concerns (timeout, retry, hedged routing, concurrency limits) by wrapping `STTProvider`. Never add special-case branches inside providers.
 
 **DI via constructor injection**: `VoxSession` accepts optional `AudioRecording`, `DictationProcessing`, `HUDDisplaying`, `PreferencesReading`. Pass `nil` for defaults. Protocols live in `VoxCore/Protocols.swift`.
 
-**Error classification**: `STTError.isRetryable`, `.isFallbackEligible`, and `.isTransientForHealthScoring` centralize error semantics across retry/fallback/routing.
+**Error classification**: `STTError.isRetryable`, `.isFallbackEligible`, and `.isTransientForHealthScoring` centralize error semantics across retry/hedge/routing.
 
 **Quality gate**: `RewriteQualityGate` compares candidate/raw character count ratio. Falls back to raw transcript if below threshold (light: 0.6, aggressive: 0.3, enhance: 0.2).
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ SuperWhisper alternative that's simpler and smarter.
 ## Features
 
 - **Press Option+Space** to start/stop recording
-- **Health-aware STT routing**: dynamically prefers healthier providers (ElevenLabs/Deepgram/Whisper) with Apple Speech as final on-device fallback
+- **Hedged STT racing**: Apple Speech + cloud providers run in a staggered race (ElevenLabs `0s`, Deepgram `5s`, Whisper `10s`)
 - **Proactive STT concurrency limiter**: queues requests before provider caps (`VOX_MAX_CONCURRENT_STT`, default `8`)
 - **Three processing levels**: Off (raw transcript), Light (cleanup), Aggressive (full rewrite)
 - **Microphone selection**: choose input device from Settings
@@ -48,9 +48,9 @@ Grant Accessibility permissions when prompted. Press Option+Space to dictate.
 - [SwiftLint](https://github.com/realm/SwiftLint) (development only, `brew install swiftlint`)
 - [ElevenLabs API key](https://elevenlabs.io) for primary transcription
 - [OpenRouter API key](https://openrouter.ai) for AI rewriting
-- [Deepgram API key](https://console.deepgram.com) (optional) for fallback transcription
-- [OpenAI API key](https://platform.openai.com) (optional) for Whisper fallback transcription
-- Apple Speech is always available as a final on-device fallback (no key needed)
+- [Deepgram API key](https://console.deepgram.com) (optional) for hedged cloud transcription
+- [OpenAI API key](https://platform.openai.com) (optional) for Whisper hedged cloud transcription
+- Apple Speech is always available and launches at hedge start (no key needed)
 
 ### Installation
 
@@ -127,7 +127,7 @@ swift run Vox
 
 ```
 Sources/
-  VoxCore/       # Protocols, errors, decorators (timeout/retry/concurrency/health-aware routing/fallback)
+  VoxCore/       # Protocols, errors, decorators (timeout/retry/concurrency/hedged racing/health-aware)
   VoxProviders/  # STT clients (ElevenLabs, Deepgram, Whisper, Apple Speech), OpenRouter rewriting
   VoxMac/        # macOS-specific: audio recording, device selection, Keychain, HUD, hotkeys
   VoxAppKit/     # Session, pipeline, settings, UI controllers (testable library)

--- a/Sources/VoxCore/HedgedSTTProvider.swift
+++ b/Sources/VoxCore/HedgedSTTProvider.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+/// Runs multiple STT providers in a staggered race and returns the first success.
+public struct HedgedSTTProvider: STTProvider {
+    public struct Entry: Sendable {
+        public let name: String
+        public let provider: STTProvider
+        public let delay: TimeInterval
+
+        public init(name: String, provider: STTProvider, delay: TimeInterval = 0) {
+            self.name = name
+            self.provider = provider
+            self.delay = delay
+        }
+    }
+
+    private enum AttemptResult {
+        case success(providerName: String, transcript: String)
+        case failure(providerName: String, error: Error)
+    }
+
+    private let entries: [Entry]
+    private let onProviderStart: (@Sendable (_ providerName: String) -> Void)?
+
+    public init(
+        entries: [Entry],
+        onProviderStart: (@Sendable (_ providerName: String) -> Void)? = nil
+    ) {
+        precondition(!entries.isEmpty, "HedgedSTTProvider requires at least one entry")
+
+        var normalized: [Entry] = []
+        var seenNames = Set<String>()
+        normalized.reserveCapacity(entries.count)
+
+        for (index, entry) in entries.enumerated() {
+            let name = entry.name.trimmingCharacters(in: .whitespacesAndNewlines)
+            precondition(!name.isEmpty, "Entry at index \(index) has an empty name")
+            precondition(entry.delay >= 0, "Entry \(name) has a negative delay")
+            precondition(!seenNames.contains(name), "Duplicate entry name: \(name)")
+            seenNames.insert(name)
+            normalized.append(Entry(name: name, provider: entry.provider, delay: entry.delay))
+        }
+
+        self.entries = normalized
+        self.onProviderStart = onProviderStart
+    }
+
+    public func transcribe(audioURL: URL) async throws -> String {
+        try await withThrowingTaskGroup(of: AttemptResult.self) { group in
+            for entry in entries {
+                group.addTask {
+                    if entry.delay > 0 {
+                        try await Task.sleep(nanoseconds: Self.delayNanoseconds(for: entry.delay))
+                    }
+                    try Task.checkCancellation()
+                    if let onProviderStart {
+                        await MainActor.run {
+                            onProviderStart(entry.name)
+                        }
+                    }
+
+                    do {
+                        let transcript = try await entry.provider.transcribe(audioURL: audioURL)
+                        return .success(providerName: entry.name, transcript: transcript)
+                    } catch is CancellationError {
+                        throw CancellationError()
+                    } catch {
+                        return .failure(providerName: entry.name, error: error)
+                    }
+                }
+            }
+
+            var lastFallbackError: Error?
+            while let result = try await group.next() {
+                switch result {
+                case .success(let providerName, let transcript):
+                    print("[STT] Hedged race winner: \(providerName)")
+                    group.cancelAll()
+                    return transcript
+
+                case .failure(let providerName, let error):
+                    if let sttError = error as? STTError, !sttError.isFallbackEligible {
+                        print("[STT] \(providerName) failed: \(sttError.localizedDescription) — stopping hedge")
+                        group.cancelAll()
+                        throw sttError
+                    }
+
+                    print("[STT] \(providerName) failed: \(error.localizedDescription) — waiting for other hedges")
+                    lastFallbackError = error
+                }
+            }
+
+            throw lastFallbackError ?? STTError.unknown("No STT providers available")
+        }
+    }
+
+    private static func delayNanoseconds(for delay: TimeInterval) -> UInt64 {
+        let nanoseconds = max(0, delay) * 1_000_000_000
+        if nanoseconds >= Double(UInt64.max) {
+            return UInt64.max
+        }
+        return UInt64(nanoseconds.rounded())
+    }
+}

--- a/Tests/VoxCoreTests/HedgedSTTProviderTests.swift
+++ b/Tests/VoxCoreTests/HedgedSTTProviderTests.swift
@@ -1,0 +1,166 @@
+import Foundation
+import XCTest
+@testable import VoxCore
+
+final class HedgedSTTProviderTests: XCTestCase {
+    private let audioURL = URL(fileURLWithPath: "/tmp/audio.wav")
+
+    func test_transcribe_returnsFirstSuccessfulResult() async throws {
+        let slowCancelled = expectation(description: "slow provider cancelled")
+        let slow = ScriptedHedgeProvider(
+            delay: 0.25,
+            result: .success("slow"),
+            onCancel: { slowCancelled.fulfill() }
+        )
+        let fast = ScriptedHedgeProvider(delay: 0.01, result: .success("fast"))
+        let provider = HedgedSTTProvider(entries: [
+            .init(name: "slow", provider: slow, delay: 0),
+            .init(name: "fast", provider: fast, delay: 0),
+        ])
+
+        let result = try await provider.transcribe(audioURL: audioURL)
+
+        XCTAssertEqual(result, "fast")
+        XCTAssertEqual(fast.callCount, 1)
+        XCTAssertEqual(slow.callCount, 1)
+        await fulfillment(of: [slowCancelled], timeout: 1.0)
+    }
+
+    func test_transcribe_skipsDelayedProviderWhenEarlierWinnerCompletes() async throws {
+        let winner = ScriptedHedgeProvider(delay: 0.01, result: .success("winner"))
+        let delayed = ScriptedHedgeProvider(delay: 0, result: .success("delayed"))
+        let provider = HedgedSTTProvider(entries: [
+            .init(name: "winner", provider: winner, delay: 0),
+            .init(name: "delayed", provider: delayed, delay: 0.2),
+        ])
+
+        let result = try await provider.transcribe(audioURL: audioURL)
+
+        XCTAssertEqual(result, "winner")
+        XCTAssertEqual(winner.callCount, 1)
+        XCTAssertEqual(delayed.callCount, 0)
+    }
+
+    func test_transcribe_failsFastOnNonFallbackEligibleError() async {
+        let invalid = ScriptedHedgeProvider(delay: 0, result: .failure(STTError.invalidAudio))
+        let delayed = ScriptedHedgeProvider(delay: 0, result: .success("should-not-run"))
+        let provider = HedgedSTTProvider(entries: [
+            .init(name: "invalid", provider: invalid, delay: 0),
+            .init(name: "delayed", provider: delayed, delay: 0.2),
+        ])
+
+        do {
+            _ = try await provider.transcribe(audioURL: audioURL)
+            XCTFail("Expected invalidAudio error")
+        } catch let error as STTError {
+            XCTAssertEqual(error, .invalidAudio)
+        } catch {
+            XCTFail("Expected STTError.invalidAudio, got \(error)")
+        }
+        XCTAssertEqual(delayed.callCount, 0)
+    }
+
+    func test_transcribe_allFallbackEligibleFailures_throwLastError() async {
+        let first = ScriptedHedgeProvider(delay: 0, result: .failure(STTError.throttled))
+        let second = ScriptedHedgeProvider(delay: 0, result: .failure(STTError.unknown("still down")))
+        let provider = HedgedSTTProvider(entries: [
+            .init(name: "first", provider: first, delay: 0),
+            .init(name: "second", provider: second, delay: 0.05),
+        ])
+
+        do {
+            _ = try await provider.transcribe(audioURL: audioURL)
+            XCTFail("Expected fallback-eligible error")
+        } catch let error as STTError {
+            XCTAssertEqual(error, .unknown("still down"))
+        } catch {
+            XCTFail("Expected STTError, got \(error)")
+        }
+    }
+
+    func test_transcribe_propagatesCancellation() async {
+        let slow = ScriptedHedgeProvider(delay: 1.0, result: .success("done"))
+        let provider = HedgedSTTProvider(entries: [
+            .init(name: "slow", provider: slow, delay: 0),
+        ])
+
+        let task = Task {
+            try await provider.transcribe(audioURL: audioURL)
+        }
+
+        try? await Task.sleep(nanoseconds: 20_000_000)
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("Expected cancellation")
+        } catch is CancellationError {
+            // Expected
+        } catch {
+            XCTFail("Expected CancellationError, got \(error)")
+        }
+    }
+}
+
+private final class ScriptedHedgeProvider: STTProvider, @unchecked Sendable {
+    private let lock = NSLock()
+    private let delay: TimeInterval
+    private let result: Result<String, Error>
+    private let onStart: (@Sendable () -> Void)?
+    private let onCancel: (@Sendable () -> Void)?
+    private var _callCount = 0
+
+    var callCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return _callCount
+    }
+
+    init(
+        delay: TimeInterval,
+        result: Result<String, Error>,
+        onStart: (@Sendable () -> Void)? = nil,
+        onCancel: (@Sendable () -> Void)? = nil
+    ) {
+        self.delay = delay
+        self.result = result
+        self.onStart = onStart
+        self.onCancel = onCancel
+    }
+
+    func transcribe(audioURL _: URL) async throws -> String {
+        incrementCallCount()
+
+        onStart?()
+
+        if delay > 0 {
+            do {
+                try await Task.sleep(nanoseconds: nanoseconds(from: delay))
+            } catch is CancellationError {
+                onCancel?()
+                throw CancellationError()
+            }
+        }
+
+        switch result {
+        case .success(let transcript):
+            return transcript
+        case .failure(let error):
+            throw error
+        }
+    }
+
+    private func nanoseconds(from duration: TimeInterval) -> UInt64 {
+        let nanoseconds = max(0, duration) * 1_000_000_000
+        if nanoseconds >= Double(UInt64.max) {
+            return UInt64.max
+        }
+        return UInt64(nanoseconds.rounded())
+    }
+
+    private func incrementCallCount() {
+        lock.lock()
+        _callCount += 1
+        lock.unlock()
+    }
+}


### PR DESCRIPTION
## Summary
- add `HedgedSTTProvider` in `VoxCore` to run staggered provider races and return first successful transcript
- replace sequential cloud-fallback composition in `VoxSession` with hedged entries (Apple 0s, ElevenLabs 0s, Deepgram 5s, Whisper 10s)
- add `HedgedSTTProviderTests` for winner selection, delayed launch behavior, cancellation propagation, fail-fast errors, and all-failure handling
- update architecture/docs (`README.md`, `docs/ARCHITECTURE.md`, `CLAUDE.md`) to reflect the new STT resilience chain

## Verification
- `swift test -Xswiftc -warnings-as-errors --filter HedgedSTTProviderTests`
- `swift build -Xswiftc -warnings-as-errors`
- `swift test -Xswiftc -warnings-as-errors`

Notes:
- Full strict test run passes; one existing test is skipped in this environment (`AudioConverterTests.test_convertCAFToOpus_outputIsSmallerThanInput`) due runtime codec availability, same as baseline behavior.

Closes #138


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hedged STT racing: Apple Speech launches immediately while cloud providers compete in parallel with staggered delays, delivering the first successful transcription result.
  * Updated UI messaging to display which provider is actively racing during transcription.

* **Documentation**
  * Updated documentation and README to reflect the new hedged routing strategy and cloud provider configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->