### PR TITLE
fix(audio): surface tap integrity failures to VoxSession

### DIFF
--- a/Sources/VoxAppKit/VoxSession.swift
+++ b/Sources/VoxAppKit/VoxSession.swift
@@ -235,6 +235,17 @@ public final class VoxSession: ObservableObject {
         let url: URL
         do {
             url = try recorder.stop()
+        } catch let error as VoxError {
+            switch error {
+            case .audioCaptureFailed:
+                await sessionExtension.didFailDictation(reason: "recording_tap_failed")
+            default:
+                await sessionExtension.didFailDictation(reason: "recording_stop_failed")
+            }
+            presentError(error.localizedDescription)
+            state = .idle
+            hud.hide()
+            return
         } catch {
             await sessionExtension.didFailDictation(reason: "recording_stop_failed")
             presentError(error.localizedDescription)

--- a/Sources/VoxCore/Errors.swift
+++ b/Sources/VoxCore/Errors.swift
@@ -98,6 +98,7 @@ public enum VoxError: Error, Sendable, Equatable, LocalizedError {
     case noFocusedElement
     case noTranscript
     case emptyCapture
+    case audioCaptureFailed(String)
     case insertionFailed
     case provider(String)
     case internalError(String)
@@ -113,6 +114,8 @@ public enum VoxError: Error, Sendable, Equatable, LocalizedError {
             return "No transcript returned."
         case .emptyCapture:
             return "No audio captured. Check input device routing and retry."
+        case .audioCaptureFailed(let msg):
+            return msg
         case .insertionFailed:
             return "Failed to insert text."
         case .provider(let msg):

--- a/Tests/VoxCoreTests/VoxErrorTests.swift
+++ b/Tests/VoxCoreTests/VoxErrorTests.swift
@@ -25,6 +25,11 @@ final class VoxErrorTests: XCTestCase {
         XCTAssertEqual(error.errorDescription, "No audio captured. Check input device routing and retry.")
     }
 
+    func test_errorDescription_audioCaptureFailed() {
+        let error = VoxError.audioCaptureFailed("Tap write failed")
+        XCTAssertEqual(error.errorDescription, "Tap write failed")
+    }
+
     func test_errorDescription_insertionFailed() {
         let error = VoxError.insertionFailed
         XCTAssertEqual(error.errorDescription, "Failed to insert text.")
@@ -50,12 +55,14 @@ final class VoxErrorTests: XCTestCase {
     func test_equatable() {
         XCTAssertEqual(VoxError.noTranscript, VoxError.noTranscript)
         XCTAssertEqual(VoxError.emptyCapture, VoxError.emptyCapture)
+        XCTAssertEqual(VoxError.audioCaptureFailed("tap"), VoxError.audioCaptureFailed("tap"))
         XCTAssertEqual(VoxError.insertionFailed, VoxError.insertionFailed)
         XCTAssertEqual(VoxError.provider("msg"), VoxError.provider("msg"))
         XCTAssertEqual(VoxError.pipelineTimeout, VoxError.pipelineTimeout)
 
         XCTAssertNotEqual(VoxError.noTranscript, VoxError.insertionFailed)
         XCTAssertNotEqual(VoxError.emptyCapture, VoxError.noTranscript)
+        XCTAssertNotEqual(VoxError.audioCaptureFailed("a"), VoxError.audioCaptureFailed("b"))
         XCTAssertNotEqual(VoxError.provider("a"), VoxError.provider("b"))
     }
 }


### PR DESCRIPTION
## Summary
- add explicit `VoxError.audioCaptureFailed(String)` for fatal capture integrity failures
- record first fatal AVAudioEngine tap/flush conversion error in `AudioRecorder` and throw it from `stop()`
- map capture-integrity stop failures in `VoxSession` to `recording_tap_failed` (while preserving `recording_stop_failed` for other stop errors)
- add tests for new `VoxError` behavior and `VoxSession` failure classification

## Validation
- `./scripts/lint.sh`
- `swift build -Xswiftc -warnings-as-errors`
- `./scripts/test-audio-guardrails.sh`
- `swift test -Xswiftc -warnings-as-errors`

Closes #175

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved audio capture failure detection with more precise error reporting during recording sessions
  * Enhanced error propagation to ensure recording failures are reliably communicated to users

* **Tests**
  * Added comprehensive test coverage for audio capture failure scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->