### PR TITLE
docs: sync README and ARCHITECTURE with current runtime behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ SuperWhisper alternative that's simpler and smarter.
 - **Press Option+Space** to start/stop recording
 - **Hedged STT racing**: Apple Speech + cloud providers run in a staggered race (ElevenLabs `0s`, Deepgram `5s`, Whisper `10s`)
 - **Proactive STT concurrency limiter**: queues requests before provider caps (`VOX_MAX_CONCURRENT_STT`, default `8`)
-- **Three processing levels**: Off (raw transcript), Light (cleanup), Aggressive (full rewrite)
+- **Four processing levels**: Off (raw transcript), Light (cleanup), Aggressive (full rewrite), Enhance (structured prompt upgrade)
 - **Microphone selection**: choose input device from Settings
 - **Auto-paste** directly into any application
 - **Menu bar app** with minimal footprint


### PR DESCRIPTION
## Summary
- update README feature copy from three to four processing levels (adds `enhance`)
- refresh architecture docs for dynamic STT timeout behavior and current cloud timeout wiring
- expand protocol architecture docs to include DI protocols currently defined in `VoxCore/Protocols.swift`
- document quality gate `enhance` thresholds (`min 0.2`, `max 15.0`)

## Verification
- `swift build -Xswiftc -warnings-as-errors`
- `swift test -Xswiftc -warnings-as-errors`

Closes #158
