### PR TITLE
feat(appkit): add product standards surface to settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,12 @@ Available via OpenRouter:
 - moonshotai/kimi-k2.5
 - google/gemini-3-flash-preview
 
+## Product Standards
+
+- **Version/build in-app**: shown in Settings footer (with deterministic debug fallback values).
+- **Attribution**: Vox by Misty Step.
+- **Contact/help**: open a support issue at https://github.com/misty-step/vox/issues.
+
 ## Contributing
 
 Contributions welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for dev setup, code style, and PR guidelines.

--- a/Sources/VoxAppKit/ProductInfo.swift
+++ b/Sources/VoxAppKit/ProductInfo.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+public struct ProductInfo: Sendable, Equatable {
+    static let fallbackVersion = "0.0.0-dev"
+    static let fallbackBuild = "local"
+    static let defaultAttribution = "Vox by Misty Step"
+    static let defaultSupportURL = URL(string: "https://github.com/misty-step/vox/issues")!
+
+    public let version: String
+    public let build: String
+    public let attribution: String
+    public let supportURL: URL
+
+    public init(
+        version: String,
+        build: String,
+        attribution: String = "Vox by Misty Step",
+        supportURL: URL = URL(string: "https://github.com/misty-step/vox/issues")!
+    ) {
+        self.version = version
+        self.build = build
+        self.attribution = attribution
+        self.supportURL = supportURL
+    }
+
+    public static func current() -> ProductInfo {
+        resolved(infoDictionary: Bundle.main.infoDictionary)
+    }
+
+    static func resolved(infoDictionary: [String: Any]?) -> ProductInfo {
+        let version = (infoDictionary?["CFBundleShortVersionString"] as? String)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let build = (infoDictionary?["CFBundleVersion"] as? String)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        return ProductInfo(
+            version: version.flatMap { $0.isEmpty ? nil : $0 } ?? fallbackVersion,
+            build: build.flatMap { $0.isEmpty ? nil : $0 } ?? fallbackBuild
+        )
+    }
+}

--- a/Sources/VoxAppKit/Settings/ProductStandardsFooter.swift
+++ b/Sources/VoxAppKit/Settings/ProductStandardsFooter.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+struct ProductStandardsFooter: View {
+    let productInfo: ProductInfo
+
+    private var versionText: String {
+        "Version \(productInfo.version) (\(productInfo.build))"
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Divider()
+            HStack(alignment: .firstTextBaseline, spacing: 12) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(versionText)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text(productInfo.attribution)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer(minLength: 0)
+
+                Link("Contact / Help", destination: productInfo.supportURL)
+                    .font(.caption.weight(.semibold))
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.bottom, 8)
+    }
+}

--- a/Sources/VoxAppKit/Settings/SettingsView.swift
+++ b/Sources/VoxAppKit/Settings/SettingsView.swift
@@ -1,16 +1,24 @@
 import SwiftUI
 
 public struct SettingsView: View {
-    public init() {}
+    private let productInfo: ProductInfo
+
+    public init(productInfo: ProductInfo = .current()) {
+        self.productInfo = productInfo
+    }
 
     public var body: some View {
-        TabView {
-            APIKeysTab()
-                .tabItem { Text("API Keys") }
-            ProcessingTab()
-                .tabItem { Text("Processing") }
+        VStack(spacing: 0) {
+            TabView {
+                APIKeysTab()
+                    .tabItem { Text("API Keys") }
+                ProcessingTab()
+                    .tabItem { Text("Processing") }
+            }
+
+            ProductStandardsFooter(productInfo: productInfo)
         }
-        .frame(minWidth: 520, minHeight: 340)
+        .frame(minWidth: 520, minHeight: 380)
         .padding(8)
     }
 }

--- a/Sources/VoxAppKit/SettingsWindowController.swift
+++ b/Sources/VoxAppKit/SettingsWindowController.swift
@@ -9,7 +9,7 @@ public final class SettingsWindowController: NSWindowController {
         let window = NSWindow(contentViewController: hosting)
         window.title = "Vox Settings"
         window.styleMask = [.titled, .closable, .miniaturizable]
-        window.setContentSize(NSSize(width: 520, height: 360))
+        window.setContentSize(NSSize(width: 520, height: 400))
         window.center()
         super.init(window: window)
     }

--- a/Tests/VoxAppTests/ProductInfoTests.swift
+++ b/Tests/VoxAppTests/ProductInfoTests.swift
@@ -1,0 +1,42 @@
+import Foundation
+import Testing
+@testable import VoxAppKit
+
+@Suite("ProductInfo")
+struct ProductInfoTests {
+    @Test("Reads version and build from bundle info dictionary")
+    func current_readsBundleInfo() {
+        let infoDictionary: [String: Any] = [
+            "CFBundleShortVersionString": "1.2.3",
+            "CFBundleVersion": "456"
+        ]
+
+        let productInfo = ProductInfo.resolved(infoDictionary: infoDictionary)
+
+        #expect(productInfo.version == "1.2.3")
+        #expect(productInfo.build == "456")
+        #expect(productInfo.attribution == "Vox by Misty Step")
+        #expect(productInfo.supportURL.absoluteString == "https://github.com/misty-step/vox/issues")
+    }
+
+    @Test("Falls back to deterministic defaults when bundle info is missing")
+    func current_fallsBackToDeterministicDefaults() {
+        let productInfo = ProductInfo.resolved(infoDictionary: nil)
+
+        #expect(productInfo.version == "0.0.0-dev")
+        #expect(productInfo.build == "local")
+    }
+
+    @Test("Treats empty bundle values as missing")
+    func current_usesFallbackForEmptyValues() {
+        let infoDictionary: [String: Any] = [
+            "CFBundleShortVersionString": "   ",
+            "CFBundleVersion": ""
+        ]
+
+        let productInfo = ProductInfo.resolved(infoDictionary: infoDictionary)
+
+        #expect(productInfo.version == "0.0.0-dev")
+        #expect(productInfo.build == "local")
+    }
+}


### PR DESCRIPTION
## Summary
- add a `ProductInfo` module that resolves app version/build metadata with deterministic fallback values
- add a product standards footer to Settings with version/build, attribution, and a contact/help link
- update README with matching product standards (provenance + support link)
- add `ProductInfo` tests covering bundle resolution and fallback behavior

## Verification
- `swift build -Xswiftc -warnings-as-errors`
- `swift test -Xswiftc -warnings-as-errors`
- pre-push hooks (lint + audio guardrails + strict tests)

Closes #179