### PR TITLE
fix(ci): bump Cerberus action to v2

### DIFF
--- a/.github/workflows/cerberus.yml
+++ b/.github/workflows/cerberus.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
-      - uses: misty-step/cerberus@v1
+      - uses: misty-step/cerberus@v2
         with:
           perspective: ${{ matrix.perspective }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -42,6 +42,6 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - uses: misty-step/cerberus/verdict@v1
+      - uses: misty-step/cerberus/verdict@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Use the current Cerberus major version in CI.

- Switches `misty-step/cerberus@v1` -> `misty-step/cerberus@v2`
- Switches `misty-step/cerberus/verdict@v1` -> `misty-step/cerberus/verdict@v2`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow infrastructure to use the latest version of a dependency checker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->