### PR TITLE
fix: correct Landfall input parameter name (llm-api-key)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,4 +24,4 @@ jobs:
         uses: misty-step/landfall@v1
         with:
           github-token: ${{ secrets.GH_RELEASE_TOKEN }}
-          moonshot-api-key: ${{ secrets.MOONSHOT_API_KEY }}
+          llm-api-key: ${{ secrets.MOONSHOT_API_KEY }}


### PR DESCRIPTION
## Problem

The release workflow was using `moonshot-api-key` as the input parameter for Landfall, but Landfall expects `llm-api-key`. This caused synthesis to be skipped on every release with the warning: `Landfall synthesis skipped; llm-api-key is empty.`

## Fix

Changed the input parameter from `moonshot-api-key` to `llm-api-key`. The secret name `MOONSHOT_API_KEY` remains the same - only the input parameter name needed to match what Landfall's action.yml expects.

## Related

- Same fix applied to bitterblossom #199