### PR TITLE
fix(streaming): scale finalize timeout by duration

### DIFF
--- a/Sources/VoxProviders/StreamingFinalizationTimeoutPolicy.swift
+++ b/Sources/VoxProviders/StreamingFinalizationTimeoutPolicy.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+struct StreamingFinalizationTimeoutPolicy: Sendable, Equatable {
+    let baseSeconds: TimeInterval
+    let secondsPerAudioSecond: TimeInterval
+    let maxSeconds: TimeInterval
+
+    init(
+        baseSeconds: TimeInterval,
+        secondsPerAudioSecond: TimeInterval,
+        maxSeconds: TimeInterval
+    ) {
+        let sanitizedBase = (baseSeconds.isFinite && baseSeconds > 0) ? baseSeconds : 5.0
+        let sanitizedSlope = (secondsPerAudioSecond.isFinite && secondsPerAudioSecond >= 0) ? secondsPerAudioSecond : 0
+        let sanitizedMax = (maxSeconds.isFinite && maxSeconds > 0) ? maxSeconds : sanitizedBase
+
+        self.baseSeconds = sanitizedBase
+        self.secondsPerAudioSecond = sanitizedSlope
+        self.maxSeconds = max(sanitizedBase, sanitizedMax)
+    }
+
+    func timeoutSeconds(forStreamedAudioSeconds seconds: TimeInterval) -> TimeInterval {
+        let audioSeconds = (seconds.isFinite && seconds > 0) ? seconds : 0
+        let proposed = baseSeconds + (audioSeconds * secondsPerAudioSecond)
+        guard proposed.isFinite, proposed > 0 else {
+            return baseSeconds
+        }
+        return min(proposed, maxSeconds)
+    }
+
+    static let `default` = StreamingFinalizationTimeoutPolicy(
+        baseSeconds: 8.0,
+        secondsPerAudioSecond: 0.05,
+        maxSeconds: 20.0
+    )
+
+    static func constant(_ seconds: TimeInterval) -> StreamingFinalizationTimeoutPolicy {
+        StreamingFinalizationTimeoutPolicy(
+            baseSeconds: seconds,
+            secondsPerAudioSecond: 0,
+            maxSeconds: seconds
+        )
+    }
+}

--- a/Tests/VoxProvidersTests/DeepgramStreamingClientTests.swift
+++ b/Tests/VoxProvidersTests/DeepgramStreamingClientTests.swift
@@ -30,7 +30,7 @@ final class DeepgramStreamingClientTests: XCTestCase {
         )
         let client = DeepgramStreamingClient(
             apiKey: "test-key",
-            sessionFinalizationTimeout: 0.5,
+            finalizationTimeoutPolicy: .constant(0.5),
             transportFactory: { _ in transport }
         )
 
@@ -69,7 +69,7 @@ final class DeepgramStreamingClientTests: XCTestCase {
         let transport = MockDeepgramWebSocketTransport(messages: [], holdReceiveForever: true)
         let client = DeepgramStreamingClient(
             apiKey: "test-key",
-            sessionFinalizationTimeout: 0.05,
+            finalizationTimeoutPolicy: .constant(0.05),
             transportFactory: { _ in transport }
         )
 
@@ -97,7 +97,7 @@ final class DeepgramStreamingClientTests: XCTestCase {
         )
         let client = DeepgramStreamingClient(
             apiKey: "test-key",
-            sessionFinalizationTimeout: 0.2,
+            finalizationTimeoutPolicy: .constant(0.2),
             transportFactory: { _ in transport }
         )
 
@@ -122,7 +122,7 @@ final class DeepgramStreamingClientTests: XCTestCase {
         )
         let client = DeepgramStreamingClient(
             apiKey: "test-key",
-            sessionFinalizationTimeout: 0.5,
+            finalizationTimeoutPolicy: .constant(0.5),
             transportFactory: { _ in transport }
         )
 
@@ -145,7 +145,7 @@ final class DeepgramStreamingClientTests: XCTestCase {
         )
         let client = DeepgramStreamingClient(
             apiKey: "test-key",
-            sessionFinalizationTimeout: 0.2,
+            finalizationTimeoutPolicy: .constant(0.2),
             transportFactory: { _ in transport }
         )
 
@@ -170,7 +170,7 @@ final class DeepgramStreamingClientTests: XCTestCase {
         )
         let client = DeepgramStreamingClient(
             apiKey: "test-key",
-            sessionFinalizationTimeout: 0.5,
+            finalizationTimeoutPolicy: .constant(0.5),
             transportFactory: { _ in transport }
         )
 

--- a/Tests/VoxProvidersTests/ElevenLabsStreamingClientTests.swift
+++ b/Tests/VoxProvidersTests/ElevenLabsStreamingClientTests.swift
@@ -28,7 +28,7 @@ final class ElevenLabsStreamingClientTests: XCTestCase {
         )
         let client = ElevenLabsStreamingClient(
             apiKey: "test-key",
-            sessionFinalizationTimeout: 0.5,
+            finalizationTimeoutPolicy: .constant(0.5),
             transportFactory: { _ in transport }
         )
 
@@ -77,7 +77,7 @@ final class ElevenLabsStreamingClientTests: XCTestCase {
         )
         let client = ElevenLabsStreamingClient(
             apiKey: "test-key",
-            sessionFinalizationTimeout: 0.5,
+            finalizationTimeoutPolicy: .constant(0.5),
             transportFactory: { _ in transport }
         )
 
@@ -108,7 +108,7 @@ final class ElevenLabsStreamingClientTests: XCTestCase {
         )
         let client = ElevenLabsStreamingClient(
             apiKey: "test-key",
-            sessionFinalizationTimeout: 0.5,
+            finalizationTimeoutPolicy: .constant(0.5),
             transportFactory: { _ in transport }
         )
 
@@ -133,7 +133,7 @@ final class ElevenLabsStreamingClientTests: XCTestCase {
         )
         let client = ElevenLabsStreamingClient(
             apiKey: "test-key",
-            sessionFinalizationTimeout: 0.5,
+            finalizationTimeoutPolicy: .constant(0.5),
             transportFactory: { _ in transport }
         )
 
@@ -155,7 +155,7 @@ final class ElevenLabsStreamingClientTests: XCTestCase {
         )
         let client = ElevenLabsStreamingClient(
             apiKey: "test-key",
-            sessionFinalizationTimeout: 0.5,
+            finalizationTimeoutPolicy: .constant(0.5),
             transportFactory: { _ in transport }
         )
 
@@ -175,7 +175,7 @@ final class ElevenLabsStreamingClientTests: XCTestCase {
         )
         let client = ElevenLabsStreamingClient(
             apiKey: "test-key",
-            sessionFinalizationTimeout: 0.2,
+            finalizationTimeoutPolicy: .constant(0.2),
             transportFactory: { _ in transport }
         )
 
@@ -194,7 +194,7 @@ final class ElevenLabsStreamingClientTests: XCTestCase {
         )
         let client = ElevenLabsStreamingClient(
             apiKey: "test-key",
-            sessionFinalizationTimeout: 0.05,
+            finalizationTimeoutPolicy: .constant(0.05),
             transportFactory: { _ in transport }
         )
 
@@ -224,7 +224,7 @@ final class ElevenLabsStreamingClientTests: XCTestCase {
         )
         let client = ElevenLabsStreamingClient(
             apiKey: "test-key",
-            sessionFinalizationTimeout: 0.5,
+            finalizationTimeoutPolicy: .constant(0.5),
             transportFactory: { _ in transport }
         )
 
@@ -251,7 +251,7 @@ final class ElevenLabsStreamingClientTests: XCTestCase {
         )
         let client = ElevenLabsStreamingClient(
             apiKey: "test-key",
-            sessionFinalizationTimeout: 0.5,
+            finalizationTimeoutPolicy: .constant(0.5),
             transportFactory: { _ in transport }
         )
 
@@ -275,7 +275,7 @@ final class ElevenLabsStreamingClientTests: XCTestCase {
         )
         let client = ElevenLabsStreamingClient(
             apiKey: "test-key",
-            sessionFinalizationTimeout: 0.2,
+            finalizationTimeoutPolicy: .constant(0.2),
             transportFactory: { _ in transport }
         )
 

--- a/Tests/VoxProvidersTests/StreamingFinalizationTimeoutPolicyTests.swift
+++ b/Tests/VoxProvidersTests/StreamingFinalizationTimeoutPolicyTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import VoxProviders
+
+final class StreamingFinalizationTimeoutPolicyTests: XCTestCase {
+    func test_constantPolicy_returnsConstant() {
+        let policy = StreamingFinalizationTimeoutPolicy.constant(0.25)
+
+        XCTAssertEqual(policy.timeoutSeconds(forStreamedAudioSeconds: 0), 0.25, accuracy: 0.0001)
+        XCTAssertEqual(policy.timeoutSeconds(forStreamedAudioSeconds: 10), 0.25, accuracy: 0.0001)
+    }
+
+    func test_scaledPolicy_increasesWithAudioSeconds_andCaps() {
+        let policy = StreamingFinalizationTimeoutPolicy(
+            baseSeconds: 5.0,
+            secondsPerAudioSecond: 0.1,
+            maxSeconds: 12.0
+        )
+
+        XCTAssertEqual(policy.timeoutSeconds(forStreamedAudioSeconds: 0), 5.0, accuracy: 0.0001)
+        XCTAssertEqual(policy.timeoutSeconds(forStreamedAudioSeconds: 10), 6.0, accuracy: 0.0001)
+        XCTAssertEqual(policy.timeoutSeconds(forStreamedAudioSeconds: 500), 12.0, accuracy: 0.0001)
+    }
+
+    func test_init_sanitizesInvalidInputs() {
+        let policy = StreamingFinalizationTimeoutPolicy(
+            baseSeconds: .infinity,
+            secondsPerAudioSecond: -.infinity,
+            maxSeconds: -1
+        )
+
+        XCTAssertEqual(policy.timeoutSeconds(forStreamedAudioSeconds: 0), 5.0, accuracy: 0.0001)
+        XCTAssertEqual(policy.timeoutSeconds(forStreamedAudioSeconds: 100), 5.0, accuracy: 0.0001)
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -87,8 +87,8 @@ Error classification is centralized in `STTError.isRetryable`, `STTError.isFallb
 2) `HotkeyMonitor` fires → `VoxSession.toggleRecording()`
 3) `VoxSession` applies selected input as system default (compatibility path), then `AudioRecorder` starts capture
 4) `AudioRecorder` records 16kHz/16-bit mono CAF via `AVAudioEngine` (default backend) and emits PCM chunks when available
-5) If Deepgram streaming is available (key present) and not disabled (`VOX_DISABLE_STREAMING_STT`), `VoxSession` forwards PCM chunks to a `StreamingSTTSession`
-6) On stop, `VoxSession` attempts streaming `finish()` with bounded timeout
+5) If streaming STT is available (ElevenLabs preferred; Deepgram fallback) and not disabled (`VOX_DISABLE_STREAMING_STT`), `VoxSession` forwards PCM chunks to a `StreamingSTTSession`
+6) On stop, `VoxSession` attempts streaming `finish()` with bounded timeout (scaled by streamed audio duration, capped)
 7) If streaming is unavailable, setup fails, or finalize fails/times out, fallback to batch STT router (default sequential; opt-in `VOX_STT_ROUTING=hedged`)
 8) Transcript → rewrite (Gemini, fallback OpenRouter) when `ProcessingLevel` = light/aggressive/enhance
 9) `RewriteQualityGate` validates output length ratio

--- a/docs/issues/195-streaming-session-flow.md
+++ b/docs/issues/195-streaming-session-flow.md
@@ -34,7 +34,7 @@ Make streaming STT the default runtime path when available, while keeping reliab
 - Streaming setup runs asynchronously with setup timeout protection.
 - `StreamingAudioBridge` buffers chunks until session attach, then drains to `StreamingSessionPump`.
 - `StreamingSessionPump` tracks latest non-empty partial transcript and uses it when `finish()` returns empty.
-- Stop flow finalizes streaming with `withStreamingFinalizeTimeout`; non-fatal failures route to batch pipeline.
+- Stop flow finalizes streaming with a bounded provider timeout (scaled by streamed audio duration); non-fatal failures route to batch pipeline.
 
 ### Module Boundaries
 - `VoxSession`: orchestration and fallback policy.


### PR DESCRIPTION
Closes #224

## Summary
- Scale streaming session finalization timeout by estimated streamed audio duration (capped) to reduce batch fallback + latency spikes on slow finalize.
- Add structured finalize outcome logs (`outcome`, `waited_ms`, `recording_s`, `reason`).
- Update docs to reflect streaming provider selection + timeout behavior.

## Verification
- `swift build -Xswiftc -warnings-as-errors`
- `swift test -Xswiftc -warnings-as-errors`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Streaming audio sessions now use intelligent timeout handling that adapts based on actual streamed audio duration, improving reliability for varying recording lengths.

* **Bug Fixes**
  * Enhanced streaming session finalization with improved error diagnostics and comprehensive timing/duration logging for better troubleshooting.

* **Tests**
  * Added test coverage for streaming timeout behavior and edge case handling.

* **Documentation**
  * Updated architecture documentation to reflect current streaming timeout mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->