### PR TITLE
feat(stt): phase-aware batch upload timeouts

### DIFF
--- a/Sources/VoxAppKit/VoxSession.swift
+++ b/Sources/VoxAppKit/VoxSession.swift
@@ -141,8 +141,7 @@ public final class VoxSession: ObservableObject {
         let elevenKey = prefs.elevenLabsAPIKey.trimmingCharacters(in: .whitespacesAndNewlines)
         if !elevenKey.isEmpty {
             let eleven = ElevenLabsClient(apiKey: elevenKey)
-            let timed = TimeoutSTTProvider(provider: eleven, baseTimeout: 30, secondsPerMB: 2)
-            let retried = RetryingSTTProvider(provider: timed, maxRetries: 3, baseDelay: 0.5, name: "ElevenLabs") { [weak self] attempt, maxRetries, delay in
+            let retried = RetryingSTTProvider(provider: eleven, maxRetries: 3, baseDelay: 0.5, name: "ElevenLabs") { [weak self] attempt, maxRetries, delay in
                 let delayStr = String(format: "%.1fs", delay)
                 Task { @MainActor in
                     self?.hud.showProcessing(message: "Retrying \(attempt)/\(maxRetries) (\(delayStr))")
@@ -154,8 +153,7 @@ public final class VoxSession: ObservableObject {
         let deepgramKey = prefs.deepgramAPIKey.trimmingCharacters(in: .whitespacesAndNewlines)
         if !deepgramKey.isEmpty {
             let deepgram = DeepgramClient(apiKey: deepgramKey)
-            let timed = TimeoutSTTProvider(provider: deepgram, baseTimeout: 30, secondsPerMB: 2)
-            let retried = RetryingSTTProvider(provider: timed, maxRetries: 2, baseDelay: 0.5, name: "Deepgram") { [weak self] attempt, maxRetries, delay in
+            let retried = RetryingSTTProvider(provider: deepgram, maxRetries: 2, baseDelay: 0.5, name: "Deepgram") { [weak self] attempt, maxRetries, delay in
                 let delayStr = String(format: "%.1fs", delay)
                 Task { @MainActor in
                     self?.hud.showProcessing(message: "Retrying \(attempt)/\(maxRetries) (\(delayStr))")
@@ -167,8 +165,7 @@ public final class VoxSession: ObservableObject {
         let openAIKey = prefs.openAIAPIKey.trimmingCharacters(in: .whitespacesAndNewlines)
         if !openAIKey.isEmpty {
             let whisper = WhisperClient(apiKey: openAIKey)
-            let timed = TimeoutSTTProvider(provider: whisper, baseTimeout: 30, secondsPerMB: 2)
-            let retried = RetryingSTTProvider(provider: timed, maxRetries: 2, baseDelay: 0.5, name: "Whisper") { [weak self] attempt, maxRetries, delay in
+            let retried = RetryingSTTProvider(provider: whisper, maxRetries: 2, baseDelay: 0.5, name: "Whisper") { [weak self] attempt, maxRetries, delay in
                 let delayStr = String(format: "%.1fs", delay)
                 Task { @MainActor in
                     self?.hud.showProcessing(message: "Retrying \(attempt)/\(maxRetries) (\(delayStr))")

--- a/Sources/VoxProviders/DeepgramClient.swift
+++ b/Sources/VoxProviders/DeepgramClient.swift
@@ -36,7 +36,14 @@ public final class DeepgramClient: STTProvider {
         request.setValue("Token \(apiKey)", forHTTPHeaderField: "Authorization")
         request.setValue(contentType, forHTTPHeaderField: "Content-Type")
 
-        let (data, response) = try await session.upload(for: request, fromFile: uploadURL)
+        let processingTimeoutSeconds = BatchSTTTimeouts.processingTimeoutSeconds(forExpectedBytes: Int64(fileSize))
+        let (data, response) = try await session.uploadWithPhaseAwareSTTTimeout(
+            for: request,
+            fromFile: uploadURL,
+            expectedBytes: Int64(fileSize),
+            uploadStallTimeoutSeconds: BatchSTTTimeouts.uploadStallTimeoutSeconds,
+            processingTimeoutSeconds: processingTimeoutSeconds
+        )
         guard let httpResponse = response as? HTTPURLResponse else {
             throw STTError.network("Invalid response")
         }

--- a/Sources/VoxProviders/ElevenLabsClient.swift
+++ b/Sources/VoxProviders/ElevenLabsClient.swift
@@ -36,7 +36,14 @@ public final class ElevenLabsClient: STTProvider {
         request.setValue(apiKey, forHTTPHeaderField: "xi-api-key")
         request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
 
-        let (data, response) = try await session.upload(for: request, fromFile: uploadFileURL)
+        let processingTimeoutSeconds = BatchSTTTimeouts.processingTimeoutSeconds(forExpectedBytes: Int64(fileSize))
+        let (data, response) = try await session.uploadWithPhaseAwareSTTTimeout(
+            for: request,
+            fromFile: uploadFileURL,
+            expectedBytes: Int64(fileSize),
+            uploadStallTimeoutSeconds: BatchSTTTimeouts.uploadStallTimeoutSeconds,
+            processingTimeoutSeconds: processingTimeoutSeconds
+        )
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw STTError.network("Invalid response")

--- a/Sources/VoxProviders/URLSession+PhaseAwareSTTTimeout.swift
+++ b/Sources/VoxProviders/URLSession+PhaseAwareSTTTimeout.swift
@@ -1,0 +1,254 @@
+import Foundation
+import VoxCore
+
+internal enum PhaseAwareSTTTimeoutPhase: String, Sendable, Equatable {
+    case uploadStall = "upload_stall"
+    case processingTimeout = "processing_timeout"
+}
+
+/// State machine for deciding which phase timed out based on upload progress.
+internal struct PhaseAwareSTTTimeoutState: Sendable {
+    private var lastBytesSent: Int64
+    private var lastProgressAt: Duration
+    private var uploadCompletedAt: Duration?
+
+    internal init(now: Duration = .zero, bytesSent: Int64 = 0) {
+        self.lastBytesSent = bytesSent
+        self.lastProgressAt = now
+        self.uploadCompletedAt = nil
+    }
+
+    internal mutating func poll(
+        now: Duration,
+        bytesSent: Int64,
+        expectedBytes: Int64,
+        uploadStallTimeout: Duration,
+        processingTimeout: Duration
+    ) -> PhaseAwareSTTTimeoutPhase? {
+        if bytesSent > lastBytesSent {
+            lastBytesSent = bytesSent
+            lastProgressAt = now
+        }
+
+        if uploadCompletedAt == nil, expectedBytes > 0, bytesSent >= expectedBytes {
+            uploadCompletedAt = now
+        }
+
+        if let uploadCompletedAt {
+            if now - uploadCompletedAt > processingTimeout {
+                return .processingTimeout
+            }
+            return nil
+        }
+
+        if now - lastProgressAt > uploadStallTimeout, bytesSent < expectedBytes {
+            return .uploadStall
+        }
+
+        return nil
+    }
+}
+
+internal enum BatchSTTTimeouts {
+    static let uploadStallTimeoutSeconds: TimeInterval = 10
+
+    // Keep existing size-based timeout budget, but apply it to server-side processing only.
+    static let processingBaseTimeoutSeconds: TimeInterval = 30
+    static let processingSecondsPerMB: TimeInterval = 2
+
+    static func processingTimeoutSeconds(forExpectedBytes expectedBytes: Int64) -> TimeInterval {
+        let sizeMB = Double(expectedBytes) / 1_048_576
+        return max(processingBaseTimeoutSeconds, processingBaseTimeoutSeconds + sizeMB * processingSecondsPerMB)
+    }
+}
+
+extension URLSession {
+    /// Phase-aware upload for batch STT:
+    /// - Upload phase: fail fast on true stalls (no progress for `uploadStallTimeoutSeconds`).
+    /// - Processing phase: once upload completes, start a separate processing timeout.
+    ///
+    /// Important: this deliberately does NOT cap slow-but-progressing uploads; the pipeline timeout is the final guardrail.
+    internal func uploadWithPhaseAwareSTTTimeout(
+        for request: URLRequest,
+        fromFile fileURL: URL,
+        expectedBytes: Int64,
+        uploadStallTimeoutSeconds: TimeInterval,
+        processingTimeoutSeconds: TimeInterval,
+        pollIntervalSeconds: TimeInterval = 0.25
+    ) async throws -> (Data, URLResponse) {
+        guard expectedBytes >= 0 else {
+            throw STTError.network("timeout(internal): invalid expectedBytes=\(expectedBytes)")
+        }
+        guard uploadStallTimeoutSeconds > 0, uploadStallTimeoutSeconds.isFinite else {
+            throw STTError.network("timeout(internal): invalid uploadStallTimeoutSeconds=\(uploadStallTimeoutSeconds)")
+        }
+        guard processingTimeoutSeconds > 0, processingTimeoutSeconds.isFinite else {
+            throw STTError.network("timeout(internal): invalid processingTimeoutSeconds=\(processingTimeoutSeconds)")
+        }
+        guard pollIntervalSeconds > 0, pollIntervalSeconds.isFinite else {
+            throw STTError.network("timeout(internal): invalid pollIntervalSeconds=\(pollIntervalSeconds)")
+        }
+
+        let state = UploadCompletionState()
+
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                state.setContinuation(continuation)
+
+                if Task.isCancelled {
+                    state.cancelFromCaller()
+                    return
+                }
+
+                let clock = ContinuousClock()
+                let startedAt = clock.now
+                var timeoutState = PhaseAwareSTTTimeoutState()
+
+                let task = uploadTask(with: request, fromFile: fileURL) { data, response, error in
+                    if let error {
+                        state.resumeOnce(.failure(error))
+                        return
+                    }
+                    guard let data, let response else {
+                        state.resumeOnce(.failure(URLError(.badServerResponse)))
+                        return
+                    }
+                    state.resumeOnce(.success((data, response)))
+                }
+                state.setTask(task)
+
+                let pollInterval = Duration.milliseconds(max(1, Int(pollIntervalSeconds * 1000)))
+                let stallTimeout = Duration.milliseconds(max(1, Int(uploadStallTimeoutSeconds * 1000)))
+                let processingTimeout = Duration.milliseconds(max(1, Int(processingTimeoutSeconds * 1000)))
+
+                let monitor = Task { [weak task] in
+                    guard let task else { return }
+
+                    while !Task.isCancelled {
+                        let bytesSent = task.countOfBytesSent
+                        let elapsed = startedAt.duration(to: clock.now)
+                        if let phase = timeoutState.poll(
+                            now: elapsed,
+                            bytesSent: bytesSent,
+                            expectedBytes: expectedBytes,
+                            uploadStallTimeout: stallTimeout,
+                            processingTimeout: processingTimeout
+                        ) {
+                            let waitedMs: Int
+                            switch phase {
+                            case .uploadStall:
+                                waitedMs = Int(uploadStallTimeoutSeconds * 1000)
+                            case .processingTimeout:
+                                waitedMs = Int(processingTimeoutSeconds * 1000)
+                            }
+                            let msg = "timeout(\(phase.rawValue)): waited=\(waitedMs)ms (sent=\(bytesSent) expected=\(expectedBytes))"
+                            state.resumeOnce(.failure(STTError.network(msg)))
+                            task.cancel()
+                            return
+                        }
+
+                        do {
+                            try await Task.sleep(for: pollInterval)
+                        } catch {
+                            return
+                        }
+                    }
+                }
+                state.setMonitor(monitor)
+
+                task.resume()
+            }
+        } onCancel: {
+            state.cancelFromCaller()
+        }
+    }
+}
+
+/// Thread-safe one-shot resume + cancellation plumbing for URLSession task bridging.
+private final class UploadCompletionState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var resumed = false
+    private var continuation: CheckedContinuation<(Data, URLResponse), Error>?
+    private var task: URLSessionTask?
+    private var monitor: Task<Void, Never>?
+    private var pendingCancellation = false
+
+    func setContinuation(_ continuation: CheckedContinuation<(Data, URLResponse), Error>) {
+        lock.lock()
+        self.continuation = continuation
+        let shouldCancel = pendingCancellation
+        lock.unlock()
+
+        if shouldCancel {
+            cancelFromCaller()
+        }
+    }
+
+    func setTask(_ task: URLSessionTask) {
+        lock.lock()
+        self.task = task
+        let shouldCancel = pendingCancellation
+        lock.unlock()
+
+        if shouldCancel {
+            cancelFromCaller()
+        }
+    }
+
+    func setMonitor(_ monitor: Task<Void, Never>) {
+        lock.lock()
+        self.monitor = monitor
+        let shouldCancel = pendingCancellation
+        lock.unlock()
+
+        if shouldCancel {
+            cancelFromCaller()
+        }
+    }
+
+    func cancelFromCaller() {
+        lock.lock()
+        pendingCancellation = true
+        let hasContinuation = continuation != nil
+        let task = task
+        let monitor = monitor
+        lock.unlock()
+
+        // If the continuation is not set yet, defer resumption until `setContinuation`.
+        guard hasContinuation else {
+            monitor?.cancel()
+            task?.cancel()
+            return
+        }
+
+        resumeOnce(.failure(CancellationError()))
+        task?.cancel()
+    }
+
+    func resumeOnce(_ result: Result<(Data, URLResponse), Error>) {
+        lock.lock()
+        guard !resumed else { lock.unlock(); return }
+        resumed = true
+
+        let continuation = continuation
+        self.continuation = nil
+        let monitor = monitor
+        self.monitor = nil
+        let task = task
+        self.task = nil
+        lock.unlock()
+
+        monitor?.cancel()
+        // If we are resuming due to timeout/cancel, ensure we stop the underlying request.
+        if case .failure = result {
+            task?.cancel()
+        }
+
+        switch result {
+        case .success(let value):
+            continuation?.resume(returning: value)
+        case .failure(let error):
+            continuation?.resume(throwing: error)
+        }
+    }
+}

--- a/Tests/VoxProvidersTests/PhaseAwareSTTTimeoutStateTests.swift
+++ b/Tests/VoxProvidersTests/PhaseAwareSTTTimeoutStateTests.swift
@@ -1,0 +1,107 @@
+import Foundation
+@testable import VoxProviders
+import XCTest
+
+final class PhaseAwareSTTTimeoutStateTests: XCTestCase {
+    func test_uploadStallTimeout_firesAfterNoProgress() {
+        var state = PhaseAwareSTTTimeoutState()
+
+        let expectedBytes: Int64 = 100
+        let stallTimeout = Duration.milliseconds(300)
+        let processingTimeout = Duration.seconds(10)
+
+        // Initial poll: no timeout.
+        XCTAssertNil(state.poll(
+            now: .milliseconds(0),
+            bytesSent: 0,
+            expectedBytes: expectedBytes,
+            uploadStallTimeout: stallTimeout,
+            processingTimeout: processingTimeout
+        ))
+
+        // Some progress at t=200ms resets stall timer.
+        XCTAssertNil(state.poll(
+            now: .milliseconds(200),
+            bytesSent: 10,
+            expectedBytes: expectedBytes,
+            uploadStallTimeout: stallTimeout,
+            processingTimeout: processingTimeout
+        ))
+
+        // No more progress; stall not yet exceeded at t=450ms (250ms since last progress).
+        XCTAssertNil(state.poll(
+            now: .milliseconds(450),
+            bytesSent: 10,
+            expectedBytes: expectedBytes,
+            uploadStallTimeout: stallTimeout,
+            processingTimeout: processingTimeout
+        ))
+
+        // Stall exceeded at t=600ms (400ms since last progress).
+        XCTAssertEqual(state.poll(
+            now: .milliseconds(600),
+            bytesSent: 10,
+            expectedBytes: expectedBytes,
+            uploadStallTimeout: stallTimeout,
+            processingTimeout: processingTimeout
+        ), .uploadStall)
+    }
+
+    func test_uploadStallTimeout_doesNotFireWhileProgressContinues() {
+        var state = PhaseAwareSTTTimeoutState()
+
+        let expectedBytes: Int64 = 100
+        let stallTimeout = Duration.milliseconds(200)
+        let processingTimeout = Duration.seconds(10)
+
+        // Progress arrives every 150ms (< stallTimeout).
+        var now = Duration.zero
+        var sent: Int64 = 0
+        for _ in 0..<5 {
+            now += .milliseconds(150)
+            sent += 10
+            XCTAssertNil(state.poll(
+                now: now,
+                bytesSent: sent,
+                expectedBytes: expectedBytes,
+                uploadStallTimeout: stallTimeout,
+                processingTimeout: processingTimeout
+            ))
+        }
+    }
+
+    func test_processingTimeout_firesOnlyAfterUploadCompletes() {
+        var state = PhaseAwareSTTTimeoutState()
+
+        let expectedBytes: Int64 = 100
+        let stallTimeout = Duration.milliseconds(300)
+        let processingTimeout = Duration.milliseconds(200)
+
+        // Upload completes at t=50ms.
+        XCTAssertNil(state.poll(
+            now: .milliseconds(50),
+            bytesSent: 100,
+            expectedBytes: expectedBytes,
+            uploadStallTimeout: stallTimeout,
+            processingTimeout: processingTimeout
+        ))
+
+        // Still within processing timeout at t=200ms (150ms after completion).
+        XCTAssertNil(state.poll(
+            now: .milliseconds(200),
+            bytesSent: 100,
+            expectedBytes: expectedBytes,
+            uploadStallTimeout: stallTimeout,
+            processingTimeout: processingTimeout
+        ))
+
+        // Processing timeout exceeded at t=300ms (250ms after completion).
+        XCTAssertEqual(state.poll(
+            now: .milliseconds(300),
+            bytesSent: 100,
+            expectedBytes: expectedBytes,
+            uploadStallTimeout: stallTimeout,
+            processingTimeout: processingTimeout
+        ), .processingTimeout)
+    }
+}


### PR DESCRIPTION
- Implements phase-aware batch STT timeouts: upload stall vs server processing.
- Adds `URLSession.uploadWithPhaseAwareSTTTimeout(...)` + state machine (VoxProviders).
- Wires ElevenLabs/Deepgram/Whisper to the helper.
- Removes `TimeoutSTTProvider` wrapping in `VoxSession` so slow-but-progressing uploads are not killed by a single wall-clock timeout.
- Adds deterministic unit tests for the phase classifier.

Verification:
- `swift test -Xswiftc -warnings-as-errors`

Closes #199
