### PR TITLE
feat: VoxCloudPreferencesReading with key caching and TTL

### DIFF
--- a/Sources/VoxAppKit/Settings/VoxCloudKeyCache.swift
+++ b/Sources/VoxAppKit/Settings/VoxCloudKeyCache.swift
@@ -1,0 +1,35 @@
+import Foundation
+import VoxCore
+import VoxMac
+
+/// Thread-safe cache for Vox Cloud API keys with TTL support.
+public actor VoxCloudKeyCache {
+    private var cachedKeys: VoxCloudKeys?
+    private var expiresAt: Date?
+    
+    public init() {}
+    
+    /// Checks if the cache has valid (non-expired) keys.
+    public var isCacheValid: Bool {
+        guard let expiresAt = expiresAt else { return false }
+        return cachedKeys != nil && expiresAt > Date()
+    }
+    
+    /// Returns the cached keys if valid, nil otherwise.
+    public func getKeys() -> VoxCloudKeys? {
+        guard isCacheValid else { return nil }
+        return cachedKeys
+    }
+    
+    /// Stores keys with expiration time.
+    public func setKeys(_ keys: VoxCloudKeys, expiresAt: Date) {
+        self.cachedKeys = keys
+        self.expiresAt = expiresAt
+    }
+    
+    /// Clears the cache.
+    public func clear() {
+        cachedKeys = nil
+        expiresAt = nil
+    }
+}

--- a/Sources/VoxAppKit/Settings/VoxCloudPreferencesReading.swift
+++ b/Sources/VoxAppKit/Settings/VoxCloudPreferencesReading.swift
@@ -1,0 +1,261 @@
+import Foundation
+import VoxCore
+import VoxMac
+
+/// Preferences reader that fetches API keys from Vox Cloud gateway.
+/// Falls back to UserDefaults for processingLevel and selectedInputDeviceUID.
+/// API keys are fetched asynchronously and cached; synchronous accessors read from cache.
+@MainActor
+public final class VoxCloudPreferencesReading: ObservableObject, PreferencesReading {
+    private let gatewayURL: URL
+    private let session: URLSession
+    private let defaults: UserDefaults
+    private let cache: VoxCloudKeyCache
+    private let onError: (String) -> Void
+    
+    /// Published error state for UI observation.
+    @Published public private(set) var lastError: String?
+    
+    /// Processing level preference.
+    @Published public var processingLevel: ProcessingLevel {
+        didSet {
+            defaults.set(processingLevel.rawValue, forKey: "processingLevel")
+        }
+    }
+    
+    /// Selected input device UID.
+    @Published public var selectedInputDeviceUID: String? {
+        didSet {
+            if let uid = selectedInputDeviceUID {
+                defaults.set(uid, forKey: "selectedInputDeviceUID")
+            } else {
+                defaults.removeObject(forKey: "selectedInputDeviceUID")
+            }
+        }
+    }
+    
+    // MARK: - PreferencesReading API Keys (Synchronous)
+    
+    public var elevenLabsAPIKey: String {
+        // Trigger background refresh if needed, return cached value
+        refreshIfNeeded()
+        return KeychainHelper.load(.elevenLabsAPIKey) ?? ""
+    }
+    
+    public var openRouterAPIKey: String {
+        refreshIfNeeded()
+        return KeychainHelper.load(.openRouterAPIKey) ?? ""
+    }
+    
+    public var deepgramAPIKey: String {
+        refreshIfNeeded()
+        return KeychainHelper.load(.deepgramAPIKey) ?? ""
+    }
+    
+    public var openAIAPIKey: String {
+        refreshIfNeeded()
+        return KeychainHelper.load(.openAIAPIKey) ?? ""
+    }
+    
+    public var geminiAPIKey: String {
+        refreshIfNeeded()
+        return KeychainHelper.load(.geminiAPIKey) ?? ""
+    }
+    
+    // MARK: - Initialization
+    
+    public init(
+        gatewayURL: URL,
+        session: URLSession = .shared,
+        defaults: UserDefaults = .standard,
+        cache: VoxCloudKeyCache = VoxCloudKeyCache(),
+        onError: @escaping (String) -> Void = { _ in }
+    ) {
+        self.gatewayURL = gatewayURL
+        self.session = session
+        self.defaults = defaults
+        self.cache = cache
+        self.onError = onError
+        
+        // Initialize from UserDefaults
+        self.processingLevel = ProcessingLevel(
+            rawValue: defaults.string(forKey: "processingLevel") ?? "light"
+        ) ?? .light
+        self.selectedInputDeviceUID = defaults.string(forKey: "selectedInputDeviceUID")
+        
+        // Trigger initial fetch in background
+        Task {
+            await refreshKeysIfNeeded()
+        }
+    }
+    
+    // MARK: - Private Helpers
+    
+    private func refreshIfNeeded() {
+        Task {
+            await refreshKeysIfNeeded()
+        }
+    }
+    
+    private func refreshKeysIfNeeded() async {
+        // Only fetch if cache is invalid
+        guard await !cache.isCacheValid else { return }
+        await fetchKeys()
+    }
+    
+    private func fetchKeys() async {
+        guard let token = KeychainHelper.load(.voxCloudToken), !token.isEmpty else {
+            let error = "Vox Cloud token not configured. Please sign in to Vox Cloud."
+            lastError = error
+            onError(error)
+            return
+        }
+        
+        var request = URLRequest(url: gatewayURL.appendingPathComponent("v1/keys"))
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        
+        do {
+            let (data, response) = try await session.data(for: request)
+            
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw VoxCloudError.invalidResponse
+            }
+            
+            guard httpResponse.statusCode == 200 else {
+                if httpResponse.statusCode == 401 {
+                    throw VoxCloudError.unauthorized
+                }
+                throw VoxCloudError.httpError(statusCode: httpResponse.statusCode)
+            }
+            
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            let keysResponse = try decoder.decode(VoxCloudKeysResponse.self, from: data)
+            
+            // Cache the keys with TTL
+            await cache.setKeys(keysResponse.keys, expiresAt: keysResponse.expiresAt)
+            
+            // Store keys in keychain for synchronous access
+            saveKeysToKeychain(keysResponse.keys)
+            
+            lastError = nil
+            
+        } catch let error as VoxCloudError {
+            let message = error.localizedDescription
+            lastError = message
+            onError(message)
+        } catch {
+            let message = "Failed to fetch keys: \(error.localizedDescription)"
+            lastError = message
+            onError(message)
+        }
+    }
+    
+    private func saveKeysToKeychain(_ keys: VoxCloudKeys) {
+        if !keys.elevenLabs.isEmpty {
+            KeychainHelper.save(keys.elevenLabs, for: .elevenLabsAPIKey)
+        }
+        if !keys.deepgram.isEmpty {
+            KeychainHelper.save(keys.deepgram, for: .deepgramAPIKey)
+        }
+        if !keys.openAI.isEmpty {
+            KeychainHelper.save(keys.openAI, for: .openAIAPIKey)
+        }
+        if !keys.gemini.isEmpty {
+            KeychainHelper.save(keys.gemini, for: .geminiAPIKey)
+        }
+        if !keys.openRouter.isEmpty {
+            KeychainHelper.save(keys.openRouter, for: .openRouterAPIKey)
+        }
+    }
+    
+    // MARK: - Public Methods
+    
+    /// Force refresh keys from the server.
+    public func refreshKeys() async {
+        await cache.clear()
+        await fetchKeys()
+    }
+    
+    /// Async method to ensure keys are fetched and return current values.
+    /// Use this when you need to guarantee fresh keys before an operation.
+    public func ensureKeys() async -> VoxCloudKeysStatus {
+        await refreshKeysIfNeeded()
+        return VoxCloudKeysStatus(
+            elevenLabsAPIKey: elevenLabsAPIKey,
+            openRouterAPIKey: openRouterAPIKey,
+            deepgramAPIKey: deepgramAPIKey,
+            openAIAPIKey: openAIAPIKey,
+            geminiAPIKey: geminiAPIKey,
+            error: lastError
+        )
+    }
+}
+
+// MARK: - Response Models
+
+struct VoxCloudKeysResponse: Codable {
+    let keys: VoxCloudKeys
+    let expiresAt: Date
+}
+
+/// API keys fetched from Vox Cloud gateway.
+public struct VoxCloudKeys: Codable {
+    public let elevenLabs: String
+    public let deepgram: String
+    public let openAI: String
+    public let gemini: String
+    public let openRouter: String
+    
+    public init(
+        elevenLabs: String = "",
+        deepgram: String = "",
+        openAI: String = "",
+        gemini: String = "",
+        openRouter: String = ""
+    ) {
+        self.elevenLabs = elevenLabs
+        self.deepgram = deepgram
+        self.openAI = openAI
+        self.gemini = gemini
+        self.openRouter = openRouter
+    }
+}
+
+/// Status snapshot of Vox Cloud keys.
+public struct VoxCloudKeysStatus: Sendable {
+    public let elevenLabsAPIKey: String
+    public let openRouterAPIKey: String
+    public let deepgramAPIKey: String
+    public let openAIAPIKey: String
+    public let geminiAPIKey: String
+    public let error: String?
+    
+    public var isReady: Bool {
+        !elevenLabsAPIKey.isEmpty && !geminiAPIKey.isEmpty
+    }
+}
+
+// MARK: - Errors
+
+enum VoxCloudError: LocalizedError {
+    case invalidResponse
+    case httpError(statusCode: Int)
+    case noToken
+    case unauthorized
+    
+    var errorDescription: String? {
+        switch self {
+        case .invalidResponse:
+            return "Invalid response from Vox Cloud"
+        case .httpError(let statusCode):
+            return "Vox Cloud API error: HTTP \(statusCode)"
+        case .noToken:
+            return "Vox Cloud token not configured"
+        case .unauthorized:
+            return "Vox Cloud token invalid or expired"
+        }
+    }
+}

--- a/Sources/VoxMac/KeychainHelper.swift
+++ b/Sources/VoxMac/KeychainHelper.swift
@@ -10,6 +10,7 @@ public enum KeychainHelper {
         case deepgramAPIKey = "com.vox.deepgram.apikey"
         case openAIAPIKey = "com.vox.openai.apikey"
         case geminiAPIKey = "com.vox.gemini.apikey"
+        case voxCloudToken = "com.vox.cloud.token"
     }
 
     @discardableResult

--- a/Tests/VoxAppTests/VoxCloudPreferencesReadingTests.swift
+++ b/Tests/VoxAppTests/VoxCloudPreferencesReadingTests.swift
@@ -1,0 +1,371 @@
+import Foundation
+import Testing
+import VoxCore
+import VoxMac
+@testable import VoxAppKit
+
+@Suite("VoxCloudPreferencesReading")
+struct VoxCloudPreferencesReadingTests {
+    private let testGatewayURL = URL(string: "https://vox-cloud.example.com")!
+    private let testToken = "test-vox-cloud-token"
+    
+    // MARK: - Test Lifecycle
+    
+    init() {
+        // Clean up any existing keys before each test
+        KeychainHelper.delete(.voxCloudToken)
+        KeychainHelper.delete(.elevenLabsAPIKey)
+        KeychainHelper.delete(.openRouterAPIKey)
+        KeychainHelper.delete(.deepgramAPIKey)
+        KeychainHelper.delete(.openAIAPIKey)
+        KeychainHelper.delete(.geminiAPIKey)
+    }
+    
+    deinit {
+        // Clean up after each test
+        KeychainHelper.delete(.voxCloudToken)
+        KeychainHelper.delete(.elevenLabsAPIKey)
+        KeychainHelper.delete(.openRouterAPIKey)
+        KeychainHelper.delete(.deepgramAPIKey)
+        KeychainHelper.delete(.openAIAPIKey)
+        KeychainHelper.delete(.geminiAPIKey)
+    }
+    
+    // MARK: - Mock URLSession
+    
+    private func createMockSession(
+        response: VoxCloudKeysResponse,
+        statusCode: Int = 200,
+        error: Error? = nil
+    ) -> URLSession {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        
+        MockURLProtocol.mockResponse = (response, statusCode, error)
+        
+        return URLSession(configuration: config)
+    }
+    
+    // MARK: - Key Caching Tests
+    
+    @Test("Keys are fetched and stored in keychain")
+    func keysAreFetchedAndStored() async throws {
+        // Given
+        KeychainHelper.save(testToken, for: .voxCloudToken)
+        
+        let response = VoxCloudKeysResponse(
+            keys: VoxCloudKeys(
+                elevenLabs: "cached-eleven-labs-key",
+                deepgram: "cached-deepgram-key",
+                openAI: "cached-openai-key",
+                gemini: "cached-gemini-key",
+                openRouter: "cached-openrouter-key"
+            ),
+            expiresAt: Date().addingTimeInterval(3600)
+        )
+        
+        let session = createMockSession(response: response)
+        let _ = VoxCloudPreferencesReading(
+            gatewayURL: testGatewayURL,
+            session: session
+        )
+        
+        // Wait for async fetch to complete
+        try await Task.sleep(for: .milliseconds(100))
+        
+        // Then - Keys should be stored in keychain
+        #expect(KeychainHelper.load(.elevenLabsAPIKey) == "cached-eleven-labs-key")
+        #expect(KeychainHelper.load(.deepgramAPIKey) == "cached-deepgram-key")
+        #expect(KeychainHelper.load(.openAIAPIKey) == "cached-openai-key")
+        #expect(KeychainHelper.load(.geminiAPIKey) == "cached-gemini-key")
+        #expect(KeychainHelper.load(.openRouterAPIKey) == "cached-openrouter-key")
+    }
+    
+    @Test("Synchronous API key accessors return cached values")
+    func synchronousAccessorsReturnCachedValues() async throws {
+        // Given - Pre-populate keychain
+        KeychainHelper.save(testToken, for: .voxCloudToken)
+        KeychainHelper.save("sync-eleven-labs", for: .elevenLabsAPIKey)
+        KeychainHelper.save("sync-gemini", for: .geminiAPIKey)
+        
+        let response = VoxCloudKeysResponse(
+            keys: VoxCloudKeys(
+                elevenLabs: "api-eleven-labs",
+                deepgram: "api-deepgram",
+                openAI: "api-openai",
+                gemini: "api-gemini",
+                openRouter: "api-openrouter"
+            ),
+            expiresAt: Date().addingTimeInterval(3600)
+        )
+        
+        let session = createMockSession(response: response)
+        let store = VoxCloudPreferencesReading(
+            gatewayURL: testGatewayURL,
+            session: session
+        )
+        
+        // When - Access synchronously (returns keychain values)
+        let elevenLabsKey = store.elevenLabsAPIKey
+        let geminiKey = store.geminiAPIKey
+        
+        // Then - Should return the cached keychain values
+        #expect(elevenLabsKey == "sync-eleven-labs")
+        #expect(geminiKey == "sync-gemini")
+    }
+    
+    // MARK: - TTL Expiry Refresh Tests
+    
+    @Test("Cache respects TTL expiration")
+    func cacheRespectsTTL() async throws {
+        // Given - Create cache with expired entry
+        let cache = VoxCloudKeyCache()
+        let expiredKeys = VoxCloudKeys(
+            elevenLabs: "expired",
+            deepgram: "expired",
+            openAI: "expired",
+            gemini: "expired",
+            openRouter: "expired"
+        )
+        await cache.setKeys(expiredKeys, expiresAt: Date().addingTimeInterval(-1))
+        
+        // Then - Cache should be invalid
+        let isValid = await cache.isCacheValid
+        #expect(!isValid)
+    }
+    
+    @Test("Cache valid when not expired")
+    func cacheValidWhenNotExpired() async throws {
+        // Given - Create cache with valid entry
+        let cache = VoxCloudKeyCache()
+        let validKeys = VoxCloudKeys(
+            elevenLabs: "valid",
+            deepgram: "valid",
+            openAI: "valid",
+            gemini: "valid",
+            openRouter: "valid"
+        )
+        await cache.setKeys(validKeys, expiresAt: Date().addingTimeInterval(3600))
+        
+        // Then - Cache should be valid
+        let isValid = await cache.isCacheValid
+        #expect(isValid)
+        
+        // And - Should return keys
+        let keys = await cache.getKeys()
+        #expect(keys?.elevenLabs == "valid")
+    }
+    
+    // MARK: - Error Handling Tests
+    
+    @Test("Clear error message when token missing")
+    func errorMessageWhenTokenMissing() async throws {
+        // Given - No token in keychain
+        var capturedError: String?
+        let store = VoxCloudPreferencesReading(
+            gatewayURL: testGatewayURL,
+            onError: { error in
+                capturedError = error
+            }
+        )
+        
+        // When - Trigger fetch via refresh
+        await store.refreshKeys()
+        
+        // Then - Error should indicate missing token
+        #expect(capturedError != nil)
+        #expect(capturedError?.contains("token") == true)
+        #expect(store.lastError?.contains("token") == true)
+    }
+    
+    @Test("Error on HTTP failure")
+    func errorOnHTTPFailure() async throws {
+        // Given
+        KeychainHelper.save(testToken, for: .voxCloudToken)
+        
+        var capturedError: String?
+        let session = createMockSession(
+            response: VoxCloudKeysResponse(
+                keys: VoxCloudKeys(),
+                expiresAt: Date()
+            ),
+            statusCode: 500
+        )
+        
+        let store = VoxCloudPreferencesReading(
+            gatewayURL: testGatewayURL,
+            session: session,
+            onError: { error in
+                capturedError = error
+            }
+        )
+        
+        // When
+        await store.refreshKeys()
+        
+        // Then
+        #expect(capturedError != nil)
+        #expect(capturedError?.contains("500") == true)
+    }
+    
+    @Test("Unauthorized error on 401")
+    func unauthorizedErrorOn401() async throws {
+        // Given
+        KeychainHelper.save(testToken, for: .voxCloudToken)
+        
+        let session = createMockSession(
+            response: VoxCloudKeysResponse(
+                keys: VoxCloudKeys(),
+                expiresAt: Date()
+            ),
+            statusCode: 401
+        )
+        
+        let store = VoxCloudPreferencesReading(
+            gatewayURL: testGatewayURL,
+            session: session
+        )
+        
+        // When
+        await store.refreshKeys()
+        
+        // Then
+        #expect(store.lastError?.contains("unauthorized") == true || store.lastError?.contains("invalid") == true)
+    }
+    
+    // MARK: - UserDefaults Delegation Tests
+    
+    @Test("Processing level delegates to UserDefaults")
+    func processingLevelDelegatesToUserDefaults() throws {
+        // Given
+        let defaults = UserDefaults(suiteName: "test-vox-cloud-prefs-\(UUID().uuidString)")!
+        
+        // Set a known value in UserDefaults
+        defaults.set(ProcessingLevel.aggressive.rawValue, forKey: "processingLevel")
+        
+        let store = VoxCloudPreferencesReading(
+            gatewayURL: testGatewayURL,
+            defaults: defaults
+        )
+        
+        // Then
+        #expect(store.processingLevel == .aggressive)
+        
+        // When - Update via store
+        store.processingLevel = .enhance
+        
+        // Then - Should persist to UserDefaults
+        #expect(defaults.string(forKey: "processingLevel") == "enhance")
+        
+        defaults.removeObject(forKey: "processingLevel")
+    }
+    
+    @Test("Selected input device UID delegates to UserDefaults")
+    func selectedInputDeviceDelegatesToUserDefaults() throws {
+        // Given
+        let defaults = UserDefaults(suiteName: "test-vox-cloud-input-\(UUID().uuidString)")!
+        
+        // Set a known value in UserDefaults
+        defaults.set("Built-in Microphone", forKey: "selectedInputDeviceUID")
+        
+        let store = VoxCloudPreferencesReading(
+            gatewayURL: testGatewayURL,
+            defaults: defaults
+        )
+        
+        // Then
+        #expect(store.selectedInputDeviceUID == "Built-in Microphone")
+        
+        // When - Update via store
+        store.selectedInputDeviceUID = "USB Microphone"
+        
+        // Then - Should persist to UserDefaults
+        #expect(defaults.string(forKey: "selectedInputDeviceUID") == "USB Microphone")
+        
+        // When - Set to nil
+        store.selectedInputDeviceUID = nil
+        
+        // Then - Should remove from UserDefaults
+        #expect(defaults.string(forKey: "selectedInputDeviceUID") == nil)
+        
+        defaults.removeObject(forKey: "selectedInputDeviceUID")
+    }
+    
+    // MARK: - Keychain Token Tests
+    
+    @Test("Vox Cloud token is stored and retrieved from Keychain")
+    func voxCloudTokenStoredInKeychain() throws {
+        // Given
+        KeychainHelper.save(testToken, for: .voxCloudToken)
+        
+        // Then - Should be retrievable
+        #expect(KeychainHelper.load(.voxCloudToken) == testToken)
+    }
+    
+    // MARK: - Protocol Conformance Tests
+    
+    @Test("Conforms to PreferencesReading protocol")
+    func conformsToPreferencesReading() throws {
+        let store = VoxCloudPreferencesReading(gatewayURL: testGatewayURL)
+        
+        // Verify all required properties exist and are accessible
+        let _: ProcessingLevel = store.processingLevel
+        let _: String? = store.selectedInputDeviceUID
+        let _: String = store.elevenLabsAPIKey
+        let _: String = store.openRouterAPIKey
+        let _: String = store.deepgramAPIKey
+        let _: String = store.openAIAPIKey
+        let _: String = store.geminiAPIKey
+    }
+}
+
+// MARK: - Mock URL Protocol
+
+class MockURLProtocol: URLProtocol {
+    static var mockResponse: (VoxCloudKeysResponse, Int, Error?)?
+    
+    override class func canInit(with request: URLRequest) -> Bool {
+        return true
+    }
+    
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        return request
+    }
+    
+    override func startLoading() {
+        guard let (response, statusCode, error) = MockURLProtocol.mockResponse else {
+            let error = NSError(domain: "MockURLProtocol", code: -1, userInfo: [NSLocalizedDescriptionKey: "No mock response set"])
+            client?.urlProtocol(self, didFailWithError: error)
+            return
+        }
+        
+        if let error = error {
+            client?.urlProtocol(self, didFailWithError: error)
+            return
+        }
+        
+        let httpResponse = HTTPURLResponse(
+            url: request.url!,
+            statusCode: statusCode,
+            httpVersion: "1.1",
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        
+        client?.urlProtocol(self, didReceive: httpResponse, cacheStoragePolicy: .notAllowed)
+        
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try! encoder.encode(response)
+        client?.urlProtocol(self, didLoad: data)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+    
+    override func stopLoading() {}
+}
+
+// MARK: - Response Model
+
+struct VoxCloudKeysResponse: Codable {
+    let keys: VoxCloudKeys
+    let expiresAt: Date
+}


### PR DESCRIPTION
Closes #25

## Summary

Implements `VoxCloudPreferencesReading` for the Vox Cloud macOS wrapper to fetch managed API keys from the gateway instead of requiring user-provided keys.

## Changes

- **VoxCloudPreferencesReading.swift**: Main implementation conforming to `PreferencesReading` protocol
  - Synchronous API key accessors (required by protocol) that read from Keychain
  - Background async fetch from Vox Cloud gateway (GET /v1/keys)
  - TTL-based cache refresh using `expiresAt` from API response
  - Error handling with user-friendly messages
  - `ensureKeys()` async method for guaranteed fresh keys

- **VoxCloudKeyCache.swift**: Thread-safe actor for key caching
  - TTL validation
  - Async cache operations

- **KeychainHelper.swift**: Added `voxCloudToken` key type for storing the auth token

- **VoxCloudPreferencesReadingTests.swift**: Comprehensive test suite
  - Key caching behavior
  - TTL expiry/refresh
  - Error handling (missing token, HTTP errors, 401 unauthorized)
  - UserDefaults delegation for `processingLevel` and `selectedInputDeviceUID`
  - Protocol conformance verification

## Design Decisions

1. **Synchronous Protocol Conformance**: `PreferencesReading` requires synchronous property access. Implementation stores fetched keys in Keychain (synchronous) and triggers background refresh when TTL expires.

2. **Keychain as Cache**: Using Keychain for cached keys provides persistence across app launches and satisfies the synchronous protocol requirements.

3. **Actor-based Cache**: `VoxCloudKeyCache` is a Swift actor ensuring thread-safe concurrent access.

## Testing

Tests use Swift Testing framework with MockURLProtocol for network interception. All major code paths covered including error scenarios.

---
*Factory autopilot run: factory-autopilot-kimi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Vox Cloud API key management system with automatic caching and TTL-based expiration.
  * Support for multiple AI service providers (ElevenLabs, OpenRouter, Deepgram, OpenAI, Gemini) with synchronized key handling.

* **Tests**
  * Added comprehensive test suite for key caching, refresh behavior, error scenarios, and provider integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->