### PR TITLE
feat: Add Vox Cloud token UX and Keychain storage

### DIFF
--- a/Sources/VoxAppKit/Settings/VoxCloudTokenSheet.swift
+++ b/Sources/VoxAppKit/Settings/VoxCloudTokenSheet.swift
@@ -1,0 +1,310 @@
+import SwiftUI
+import VoxCore
+import VoxMac
+
+/// Connection status for Vox Cloud token
+enum VoxCloudConnectionStatus: Equatable {
+    case missing
+    case testing
+    case invalidToken
+    case error(String)
+    case ready(used: Int, remaining: Int)
+
+    var isReady: Bool {
+        if case .ready = self { return true }
+        return false
+    }
+
+    var displayText: String {
+        switch self {
+        case .missing:
+            return "No token configured"
+        case .testing:
+            return "Testing connection..."
+        case .invalidToken:
+            return "Invalid token"
+        case .error(let message):
+            return "Error: \(message)"
+        case .ready(let used, let remaining):
+            return "Connected • \(remaining) min remaining of \(used + remaining) total"
+        }
+    }
+
+    var statusColor: Color {
+        switch self {
+        case .missing:
+            return .secondary
+        case .testing:
+            return .orange
+        case .invalidToken, .error:
+            return .red
+        case .ready:
+            return .green
+        }
+    }
+}
+
+/// Sheet for entering and managing Vox Cloud token
+struct VoxCloudTokenSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @ObservedObject private var prefs = PreferencesStore.shared
+
+    @State private var tokenInput: String = ""
+    @State private var connectionStatus: VoxCloudConnectionStatus = .missing
+    @State private var isTesting = false
+
+    private let api = VoxCloudAPI()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            headerSection
+            Divider()
+            contentSection
+            Divider()
+            footerSection
+        }
+        .frame(minWidth: 520, minHeight: 380)
+        .onAppear {
+            loadExistingToken()
+        }
+    }
+
+    private var headerSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Vox Cloud")
+                .font(.title3.weight(.semibold))
+            Text("Enter your Vox Cloud token to enable cloud transcription and rewriting without individual provider keys.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 16)
+        .padding(.top, 14)
+        .padding(.bottom, 10)
+    }
+
+    private var contentSection: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            GroupBox {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Vox Cloud Token")
+                        .font(.subheadline.weight(.semibold))
+
+                    if hasStoredToken {
+                        HStack {
+                            Text(String(repeating: "•", count: 24))
+                                .font(.system(.body, design: .monospaced))
+                                .foregroundStyle(.secondary)
+                            Spacer()
+                            Button("Clear") {
+                                clearToken()
+                            }
+                            .foregroundStyle(.red)
+                        }
+                    } else {
+                        SecureField("Enter your Vox Cloud token", text: $tokenInput)
+                            .textContentType(.password)
+                            .textFieldStyle(.roundedBorder)
+                    }
+
+                    Text("Get your token from your Vox Cloud dashboard.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(12)
+            }
+
+            statusSection
+
+            HStack(spacing: 12) {
+                Button(action: testConnection) {
+                    HStack {
+                        if isTesting {
+                            ProgressView()
+                                .scaleEffect(0.7)
+                        }
+                        Text("Test Connection")
+                    }
+                }
+                .disabled(isTesting || (tokenInput.isEmpty && !hasStoredToken))
+
+                if hasStoredToken {
+                    Button(action: testConnection) {
+                        Text("Refresh Status")
+                    }
+                    .disabled(isTesting)
+                }
+            }
+        }
+        .padding(16)
+    }
+
+    private var statusSection: some View {
+        GroupBox {
+            HStack {
+                Circle()
+                    .fill(connectionStatus.statusColor)
+                    .frame(width: 8, height: 8)
+                Text(connectionStatus.displayText)
+                    .font(.subheadline)
+                    .foregroundStyle(connectionStatus.statusColor)
+                Spacer()
+            }
+            .padding(8)
+
+            if case .error = connectionStatus, let error = connectionStatusError {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(error.localizedDescription)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    if let suggestion = error.recoverySuggestion {
+                        Text(suggestion)
+                            .font(.caption)
+                            .foregroundStyle(.blue)
+                    }
+                }
+                .padding(8)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color.red.opacity(0.1))
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+            }
+
+            if case .invalidToken = connectionStatus {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("The token you entered is invalid or has been revoked.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text("Go to your Vox Cloud dashboard to generate a new token.")
+                        .font(.caption)
+                        .foregroundStyle(.blue)
+                }
+                .padding(8)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color.red.opacity(0.1))
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+            }
+
+            if connectionStatus.isReady {
+                quotaSection
+            }
+        }
+    }
+
+    private var quotaSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Quota Status")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+
+            if case .ready(let used, let remaining) = connectionStatus {
+                let total = used + remaining
+                let usedPercent = total > 0 ? Double(used) / Double(total) : 0
+
+                ProgressView(value: usedPercent)
+                    .tint(usedPercent > 0.8 ? .red : .green)
+
+                HStack {
+                    Text("\(used) min used")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Text("\(remaining) min remaining")
+                        .font(.caption)
+                        .foregroundStyle(remaining < 100 ? .red : .secondary)
+                }
+            }
+        }
+        .padding(8)
+    }
+
+    private var footerSection: some View {
+        HStack {
+            Spacer(minLength: 0)
+            Button("Close") { dismiss() }
+                .keyboardShortcut(.cancelAction)
+        }
+        .padding(16)
+    }
+
+    private var hasStoredToken: Bool {
+        !prefs.voxCloudToken.isEmpty
+    }
+
+    private var connectionStatusError: Error? {
+        switch connectionStatus {
+        case .error(let message):
+            return NSError(domain: "VoxCloud", code: -1, userInfo: [NSLocalizedDescriptionKey: message])
+        case .invalidToken:
+            return VoxCloudAPIError.invalidToken
+        default:
+            return nil
+        }
+    }
+
+    private func loadExistingToken() {
+        if hasStoredToken {
+            connectionStatus = .ready(used: 0, remaining: 0)
+            Task {
+                await testConnectionAndUpdateStatus()
+            }
+        } else {
+            connectionStatus = .missing
+        }
+    }
+
+    private func testConnection() {
+        if !tokenInput.isEmpty {
+            prefs.voxCloudToken = tokenInput
+            tokenInput = ""
+        }
+        Task {
+            await testConnectionAndUpdateStatus()
+        }
+    }
+
+    private func testConnectionAndUpdateStatus() async {
+        isTesting = true
+        connectionStatus = .testing
+
+        let token = prefs.voxCloudToken
+        guard !token.isEmpty else {
+            connectionStatus = .missing
+            isTesting = false
+            return
+        }
+
+        do {
+            let quota = try await api.fetchQuota(token: token)
+            connectionStatus = .ready(used: quota.used, remaining: quota.remaining)
+            prefs.voxCloudEnabled = true
+        } catch let error as VoxCloudAPIError {
+            switch error {
+            case .invalidToken:
+                connectionStatus = .invalidToken
+            default:
+                connectionStatus = .error(error.localizedDescription)
+            }
+            prefs.voxCloudEnabled = false
+        } catch {
+            connectionStatus = .error(error.localizedDescription)
+            prefs.voxCloudEnabled = false
+        }
+
+        isTesting = false
+    }
+
+    private func clearToken() {
+        prefs.voxCloudToken = ""
+        prefs.voxCloudEnabled = false
+        connectionStatus = .missing
+    }
+}
+
+#if DEBUG
+struct VoxCloudTokenSheet_Previews: PreviewProvider {
+    static var previews: some View {
+        VoxCloudTokenSheet()
+    }
+}
+#endif

--- a/Sources/VoxCore/VoxCloudAPI.swift
+++ b/Sources/VoxCore/VoxCloudAPI.swift
@@ -1,0 +1,124 @@
+import Foundation
+
+/// API client for Vox Cloud service
+public struct VoxCloudAPI {
+    public let baseURL: URL
+    public let session: URLSession
+
+    public init(baseURL: URL = URL(string: "https://api.misty-step.com")!, session: URLSession = .shared) {
+        self.baseURL = baseURL
+        self.session = session
+    }
+
+    /// Fetches the user's quota information
+    /// - Parameter token: The Vox Cloud Bearer token
+    /// - Returns: Quota information containing used and remaining allocation
+    public func fetchQuota(token: String) async throws -> VoxCloudQuota {
+        let url = baseURL.appendingPathComponent("v1/quota")
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let (data, response) = try await session.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw VoxCloudAPIError.networkError
+        }
+
+        switch httpResponse.statusCode {
+        case 200:
+            let decoder = JSONDecoder()
+            return try decoder.decode(VoxCloudQuota.self, from: data)
+        case 401:
+            throw VoxCloudAPIError.invalidToken
+        case 403:
+            throw VoxCloudAPIError.forbidden
+        case 404:
+            throw VoxCloudAPIError.notFound
+        default:
+            throw VoxCloudAPIError.serverError(statusCode: httpResponse.statusCode)
+        }
+    }
+}
+
+/// Quota information returned by the Vox Cloud API
+public struct VoxCloudQuota: Codable {
+    public let used: Int
+    public let remaining: Int
+    public let total: Int
+
+    public init(used: Int, remaining: Int, total: Int) {
+        self.used = used
+        self.remaining = remaining
+        self.total = total
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case used
+        case remaining
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        used = try container.decode(Int.self, forKey: .used)
+        remaining = try container.decode(Int.self, forKey: .remaining)
+        total = used + remaining
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(used, forKey: .used)
+        try container.encode(remaining, forKey: .remaining)
+    }
+}
+
+/// Errors that can occur when interacting with the Vox Cloud API
+public enum VoxCloudAPIError: Error, LocalizedError {
+    case invalidToken
+    case forbidden
+    case notFound
+    case networkError
+    case serverError(statusCode: Int)
+    case decodingError
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidToken:
+            return "Invalid Vox Cloud token. Please check your token and try again."
+        case .forbidden:
+            return "Access forbidden. Your token may have insufficient permissions."
+        case .notFound:
+            return "API endpoint not found. Please ensure you're using the correct API version."
+        case .networkError:
+            return "Network error. Please check your internet connection."
+        case .serverError(let statusCode):
+            return "Server error (HTTP \(statusCode)). Please try again later."
+        case .decodingError:
+            return "Failed to parse server response."
+        }
+    }
+
+    public var recoverySuggestion: String? {
+        switch self {
+        case .invalidToken:
+            return "Go to Settings → Vox Cloud and re-enter your token, or generate a new one from your Vox Cloud dashboard."
+        case .forbidden:
+            return "Contact support if you believe this is an error."
+        case .notFound:
+            return "This may be a temporary issue. Please try again."
+        case .networkError:
+            return "Check your internet connection and try again."
+        case .serverError:
+            return "Please try again in a few moments."
+        case .decodingError:
+            return "This may indicate a service upgrade. Please update the app."
+        }
+    }
+}
+
+#if DEBUG
+extension VoxCloudQuota {
+    static let preview = VoxCloudQuota(used: 150, remaining: 850, total: 1000)
+}
+#endif

--- a/Sources/VoxMac/KeychainHelper.swift
+++ b/Sources/VoxMac/KeychainHelper.swift
@@ -10,6 +10,7 @@ public enum KeychainHelper {
         case deepgramAPIKey = "com.vox.deepgram.apikey"
         case openAIAPIKey = "com.vox.openai.apikey"
         case geminiAPIKey = "com.vox.gemini.apikey"
+        case voxCloudToken = "com.vox.cloud.token"
     }
 
     @discardableResult

--- a/Tests/VoxAppTests/VoxCloudTokenTests.swift
+++ b/Tests/VoxAppTests/VoxCloudTokenTests.swift
@@ -1,0 +1,127 @@
+import XCTest
+import SwiftUI
+@testable import VoxAppKit
+
+final class VoxCloudTokenTests: XCTestCase {
+
+    override func tearDown() {
+        // Clean up any stored tokens after each test
+        KeychainHelper.delete(.voxCloudToken)
+        super.tearDown()
+    }
+
+    // MARK: - KeychainHelper Tests for VoxCloudToken
+
+    func testKeychainHelper_SaveAndLoadVoxCloudToken() {
+        let token = "test-vox-cloud-token-12345"
+
+        let saveResult = KeychainHelper.save(token, for: .voxCloudToken)
+        XCTAssertTrue(saveResult, "Should successfully save token to keychain")
+
+        let loadedToken = KeychainHelper.load(.voxCloudToken)
+        XCTAssertEqual(loadedToken, token, "Should load the same token that was saved")
+    }
+
+    func testKeychainHelper_LoadNonExistentToken() {
+        // Ensure no token exists
+        KeychainHelper.delete(.voxCloudToken)
+
+        let loadedToken = KeychainHelper.load(.voxCloudToken)
+        XCTAssertNil(loadedToken, "Should return nil for non-existent token")
+    }
+
+    func testKeychainHelper_DeleteVoxCloudToken() {
+        let token = "test-vox-cloud-token-12345"
+
+        KeychainHelper.save(token, for: .voxCloudToken)
+        let loadedBeforeDelete = KeychainHelper.load(.voxCloudToken)
+        XCTAssertEqual(loadedBeforeDelete, token, "Token should exist before deletion")
+
+        let deleteResult = KeychainHelper.delete(.voxCloudToken)
+        XCTAssertTrue(deleteResult, "Should successfully delete token from keychain")
+
+        let loadedAfterDelete = KeychainHelper.load(.voxCloudToken)
+        XCTAssertNil(loadedAfterDelete, "Token should be nil after deletion")
+    }
+
+    func testKeychainHelper_UpdateVoxCloudToken() {
+        let firstToken = "first-token"
+        let secondToken = "second-token"
+
+        KeychainHelper.save(firstToken, for: .voxCloudToken)
+        let loadedFirst = KeychainHelper.load(.voxCloudToken)
+        XCTAssertEqual(loadedFirst, firstToken, "Should load first token")
+
+        // Save should overwrite the existing token
+        KeychainHelper.save(secondToken, for: .voxCloudToken)
+        let loadedSecond = KeychainHelper.load(.voxCloudToken)
+        XCTAssertEqual(loadedSecond, secondToken, "Should load second token after update")
+    }
+
+    // MARK: - PreferencesStore Tests
+
+    func testPreferencesStore_VoxCloudToken() {
+        let token = "preferences-store-test-token"
+        let prefs = PreferencesStore.shared
+
+        prefs.voxCloudToken = token
+        XCTAssertEqual(prefs.voxCloudToken, token, "Should store and retrieve token via PreferencesStore")
+
+        // Clean up
+        prefs.voxCloudToken = ""
+    }
+
+    func testPreferencesStore_VoxCloudToken_Clear() {
+        let prefs = PreferencesStore.shared
+
+        prefs.voxCloudToken = "some-token"
+        XCTAssertFalse(prefs.voxCloudToken.isEmpty, "Token should be set")
+
+        prefs.voxCloudToken = ""
+        XCTAssertTrue(prefs.voxCloudToken.isEmpty, "Token should be empty after clearing")
+    }
+
+    func testPreferencesStore_VoxCloudEnabled_Default() {
+        let prefs = PreferencesStore.shared
+
+        // Default should be false when no token is set
+        XCTAssertFalse(prefs.voxCloudEnabled, "VoxCloudEnabled should default to false")
+    }
+
+    // MARK: - VoxCloudConnectionStatus Tests
+
+    func testVoxCloudConnectionStatus_Equatable() {
+        let status1: VoxCloudConnectionStatus = .ready(used: 100, remaining: 200)
+        let status2: VoxCloudConnectionStatus = .ready(used: 100, remaining: 200)
+        let status3: VoxCloudConnectionStatus = .ready(used: 150, remaining: 200)
+
+        XCTAssertEqual(status1, status2, "Same status values should be equal")
+        XCTAssertNotEqual(status1, status3, "Different status values should not be equal")
+    }
+
+    func testVoxCloudConnectionStatus_IsReady() {
+        XCTAssertFalse(VoxCloudConnectionStatus.missing.isReady, "Missing should not be ready")
+        XCTAssertFalse(VoxCloudConnectionStatus.testing.isReady, "Testing should not be ready")
+        XCTAssertFalse(VoxCloudConnectionStatus.invalidToken.isReady, "InvalidToken should not be ready")
+        XCTAssertFalse(VoxCloudConnectionStatus.error("test").isReady, "Error should not be ready")
+        XCTAssertTrue(VoxCloudConnectionStatus.ready(used: 0, remaining: 100).isReady, "Ready should be ready")
+    }
+
+    func testVoxCloudConnectionStatus_DisplayText() {
+        XCTAssertEqual(VoxCloudConnectionStatus.missing.displayText, "No token configured")
+        XCTAssertEqual(VoxCloudConnectionStatus.testing.displayText, "Testing connection...")
+        XCTAssertEqual(VoxCloudConnectionStatus.invalidToken.displayText, "Invalid token")
+        XCTAssertEqual(VoxCloudConnectionStatus.error("test error").displayText, "Error: test error")
+        XCTAssertEqual(VoxCloudConnectionStatus.ready(used: 100, remaining: 200).displayText, "Connected • 200 min remaining of 300 total")
+    }
+
+    // MARK: - VoxCloudQuota Tests
+
+    func testVoxCloudQuota_Preview() {
+        let quota = VoxCloudQuota.preview
+
+        XCTAssertEqual(quota.used, 150)
+        XCTAssertEqual(quota.remaining, 850)
+        XCTAssertEqual(quota.total, 1000)
+    }
+}

--- a/Tests/VoxCoreTests/VoxCloudAPITests.swift
+++ b/Tests/VoxCoreTests/VoxCloudAPITests.swift
@@ -1,0 +1,237 @@
+import XCTest
+@testable import VoxCore
+
+final class VoxCloudAPITests: XCTestCase {
+    var api: VoxCloudAPI!
+    var mockSession: MockURLSession!
+
+    override func setUp() {
+        super.setUp()
+        mockSession = MockURLSession()
+        api = VoxCloudAPI(baseURL: URL(string: "https://api.misty-step.com")!, session: mockSession)
+    }
+
+    override func tearDown() {
+        api = nil
+        mockSession = nil
+        super.tearDown()
+    }
+
+    // MARK: - fetchQuota Tests
+
+    func testFetchQuota_Success() async throws {
+        let jsonData = """
+        {
+            "used": 150,
+            "remaining": 850
+        }
+        """.data(using: .utf8)!
+
+        mockSession.nextData = jsonData
+        mockSession.nextResponse = HTTPURLResponse(
+            url: URL(string: "https://api.misty-step.com/v1/quota")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )
+
+        let quota = try await api.fetchQuota(token: "test-token")
+
+        XCTAssertEqual(quota.used, 150)
+        XCTAssertEqual(quota.remaining, 850)
+        XCTAssertEqual(quota.total, 1000)
+
+        XCTAssertEqual(mockSession.lastRequest?.value(forHTTPHeaderField: "Authorization"), "Bearer test-token")
+    }
+
+    func testFetchQuota_InvalidToken() async throws {
+        mockSession.nextData = Data()
+        mockSession.nextResponse = HTTPURLResponse(
+            url: URL(string: "https://api.misty-step.com/v1/quota")!,
+            statusCode: 401,
+            httpVersion: nil,
+            headerFields: nil
+        )
+
+        do {
+            _ = try await api.fetchQuota(token: "invalid-token")
+            XCTFail("Expected invalidToken error")
+        } catch let error as VoxCloudAPIError {
+            XCTAssertEqual(error, .invalidToken)
+        }
+    }
+
+    func testFetchQuota_Forbidden() async throws {
+        mockSession.nextData = Data()
+        mockSession.nextResponse = HTTPURLResponse(
+            url: URL(string: "https://api.misty-step.com/v1/quota")!,
+            statusCode: 403,
+            httpVersion: nil,
+            headerFields: nil
+        )
+
+        do {
+            _ = try await api.fetchQuota(token: "test-token")
+            XCTFail("Expected forbidden error")
+        } catch let error as VoxCloudAPIError {
+            XCTAssertEqual(error, .forbidden)
+        }
+    }
+
+    func testFetchQuota_NotFound() async throws {
+        mockSession.nextData = Data()
+        mockSession.nextResponse = HTTPURLResponse(
+            url: URL(string: "https://api.misty-step.com/v1/quota")!,
+            statusCode: 404,
+            httpVersion: nil,
+            headerFields: nil
+        )
+
+        do {
+            _ = try await api.fetchQuota(token: "test-token")
+            XCTFail("Expected notFound error")
+        } catch let error as VoxCloudAPIError {
+            XCTAssertEqual(error, .notFound)
+        }
+    }
+
+    func testFetchQuota_ServerError() async throws {
+        mockSession.nextData = Data()
+        mockSession.nextResponse = HTTPURLResponse(
+            url: URL(string: "https://api.misty-step.com/v1/quota")!,
+            statusCode: 500,
+            httpVersion: nil,
+            headerFields: nil
+        )
+
+        do {
+            _ = try await api.fetchQuota(token: "test-token")
+            XCTFail("Expected serverError")
+        } catch let error as VoxCloudAPIError {
+            if case .serverError(let statusCode) = error {
+                XCTAssertEqual(statusCode, 500)
+            } else {
+                XCTFail("Expected serverError")
+            }
+        }
+    }
+
+    func testFetchQuota_NetworkError() async throws {
+        mockSession.nextError = NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet)
+
+        do {
+            _ = try await api.fetchQuota(token: "test-token")
+            XCTFail("Expected networkError")
+        } catch let error as VoxCloudAPIError {
+            XCTAssertEqual(error, .networkError)
+        }
+    }
+
+    func testFetchQuota_DecodingError() async throws {
+        let jsonData = """
+        {
+            "used": "not-a-number",
+            "remaining": 850
+        }
+        """.data(using: .utf8)!
+
+        mockSession.nextData = jsonData
+        mockSession.nextResponse = HTTPURLResponse(
+            url: URL(string: "https://api.misty-step.com/v1/quota")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )
+
+        do {
+            _ = try await api.fetchQuota(token: "test-token")
+            XCTFail("Expected decodingError")
+        } catch {
+            // Any decoding error is acceptable
+            XCTAssertTrue(true)
+        }
+    }
+}
+
+// MARK: - VoxCloudQuota Tests
+
+extension VoxCloudAPITests {
+    func testVoxCloudQuota_Codable() throws {
+        let json = """
+        {
+            "used": 100,
+            "remaining": 400
+        }
+        """.data(using: .utf8)!
+
+        let quota = try JSONDecoder().decode(VoxCloudQuota.self, from: json)
+
+        XCTAssertEqual(quota.used, 100)
+        XCTAssertEqual(quota.remaining, 400)
+        XCTAssertEqual(quota.total, 500)
+    }
+
+    func testVoxCloudQuota_TotalCalculation() throws {
+        let quota = VoxCloudQuota(used: 250, remaining: 750, total: 0)
+
+        XCTAssertEqual(quota.used, 250)
+        XCTAssertEqual(quota.remaining, 750)
+        XCTAssertEqual(quota.total, 1000)
+    }
+}
+
+// MARK: - VoxCloudAPIError Tests
+
+extension VoxCloudAPITests {
+    func testVoxCloudAPIError_InvalidToken_Description() {
+        let error = VoxCloudAPIError.invalidToken
+
+        XCTAssertNotNil(error.errorDescription)
+        XCTAssertNotNil(error.recoverySuggestion)
+    }
+
+    func testVoxCloudAPIError_Forbidden_Description() {
+        let error = VoxCloudAPIError.forbidden
+
+        XCTAssertNotNil(error.errorDescription)
+        XCTAssertNotNil(error.recoverySuggestion)
+    }
+
+    func testVoxCloudAPIError_NotFound_Description() {
+        let error = VoxCloudAPIError.notFound
+
+        XCTAssertNotNil(error.errorDescription)
+        XCTAssertNotNil(error.recoverySuggestion)
+    }
+
+    func testVoxCloudAPIError_NetworkError_Description() {
+        let error = VoxCloudAPIError.networkError
+
+        XCTAssertNotNil(error.errorDescription)
+        XCTAssertNotNil(error.recoverySuggestion)
+    }
+
+    func testVoxCloudAPIError_ServerError_Description() {
+        let error = VoxCloudAPIError.serverError(statusCode: 503)
+
+        XCTAssertNotNil(error.errorDescription)
+        XCTAssertNotNil(error.recoverySuggestion)
+    }
+}
+
+// MARK: - Mock URLSession
+
+private class MockURLSession: URLSession {
+    var nextData: Data?
+    var nextResponse: URLResponse?
+    var nextError: Error?
+    var lastRequest: URLRequest?
+
+    override func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        lastRequest = request
+        if let error = nextError {
+            throw error
+        }
+        return (nextData ?? Data(), nextResponse ?? HTTPURLResponse())
+    }
+}


### PR DESCRIPTION
## Summary

This PR implements the Vox Cloud token UX and Keychain storage for the Vox macOS app (Issue #24).

### Changes:

1. **KeychainHelper.swift**: Added  case to the  enum for secure token storage.

2. **VoxCloudAPI.swift** (new): Created API client for Vox Cloud with:
   -  method to call  with Bearer token auth
   -  struct for parsing quota responses (used/remaining fields)
   -  enum with proper error handling (401 invalid token, network errors, etc.)

3. **VoxCloudTokenSheet.swift** (new): Created UI sheet with:
   - Single secure text field for Vox Cloud Token
   - "Test Connection" button that verifies token and shows quota status
   - Connection status states: missing → testing → invalid token → ready
   - Quota display with progress bar showing used/remaining
   - Token redaction (shows dots) after save
   - Clear error messages with recovery suggestions

4. **PreferencesStore.swift**: Added:
   -  property with Keychain storage
   -  property to track if Vox Cloud mode is active

5. **SettingsView.swift**: Updated to support Vox Cloud mode:
   - Header changes to show "Vox Cloud Enabled" when connected
   - Toggle between BYOK and Vox Cloud sections
   -  shows when Vox Cloud is enabled

6. **Tests**:
   - : Tests for API client parsing, error handling, token validation
   - : Tests for Keychain storage/retrieval and UI state transitions

### Key Constraints Met:
- Token stored in Keychain, never logged
- Follows existing code style in the repo
- Uses Swift Concurrency (async/await) for API calls

Closes misty-step/vox-cloud#24