### PR TITLE
feat: make API readiness messaging state-aware (local vs cloud paths)

### DIFF
--- a/Tests/VoxAppTests/StatusBarMenuSnapshotTests.swift
+++ b/Tests/VoxAppTests/StatusBarMenuSnapshotTests.swift
@@ -29,14 +29,14 @@ struct StatusBarMenuSnapshotTests {
 
         #expect(snapshot.statusTitle == "Status: Recording")
         #expect(snapshot.modeTitle == "Mode: Aggressive")
-        #expect(snapshot.cloudTitle == "Cloud STT ready; rewrite missing")
+        #expect(snapshot.cloudTitle == "Cloud STT ready; rewrite not configured")
         #expect(snapshot.cloudNeedsAction == true)
         #expect(snapshot.toggleTitle == "Stop Dictation")
         #expect(snapshot.toggleEnabled == true)
     }
 
-    @Test("Processing snapshot disables toggle and reports local-only STT")
-    func processingSnapshotDisablesToggle() {
+    @Test("Processing snapshot in Off mode with no cloud shows on-device status")
+    func processingSnapshotOffModeNoCloud() {
         let snapshot = StatusBarMenuSnapshot.make(
             state: .processing(processingLevel: .off),
             hasCloudSTT: false,
@@ -45,10 +45,22 @@ struct StatusBarMenuSnapshotTests {
 
         #expect(snapshot.statusTitle == "Status: Processing")
         #expect(snapshot.modeTitle == "Mode: Off")
-        #expect(snapshot.cloudTitle == "Cloud services: Not configured")
-        #expect(snapshot.cloudNeedsAction == true)
+        #expect(snapshot.cloudTitle == "On-device transcription")
+        #expect(snapshot.cloudNeedsAction == false)
         #expect(snapshot.toggleTitle == "Start Dictation")
         #expect(snapshot.toggleEnabled == false)
+    }
+
+    @Test("Off mode with cloud STT shows cloud transcription ready")
+    func offModeWithCloudSTT() {
+        let snapshot = StatusBarMenuSnapshot.make(
+            state: .idle(processingLevel: .off),
+            hasCloudSTT: true,
+            hasRewrite: false
+        )
+
+        #expect(snapshot.cloudTitle == "Cloud transcription ready")
+        #expect(snapshot.cloudNeedsAction == false)
     }
 
     @Test("Rewrite-only setup message is explicit")
@@ -59,8 +71,8 @@ struct StatusBarMenuSnapshotTests {
             hasRewrite: true
         )
 
-        #expect(snapshot.cloudTitle == "Rewrite ready; transcription local")
-        #expect(snapshot.cloudNeedsAction == true)
+        #expect(snapshot.cloudTitle == "Rewrite ready; transcription on-device")
+        #expect(snapshot.cloudNeedsAction == false)
     }
 
     @Test("Enhance level label is preserved")
@@ -72,5 +84,29 @@ struct StatusBarMenuSnapshotTests {
         )
 
         #expect(snapshot.modeTitle == "Mode: Enhance")
+    }
+
+    @Test("Light mode with no cloud services shows limited mode message")
+    func lightModeNoCloudShowsLimited() {
+        let snapshot = StatusBarMenuSnapshot.make(
+            state: .idle(processingLevel: .light),
+            hasCloudSTT: false,
+            hasRewrite: false
+        )
+
+        #expect(snapshot.cloudTitle == "Cloud services not configured; limited to Off mode")
+        #expect(snapshot.cloudNeedsAction == true)
+    }
+
+    @Test("Aggressive mode with cloud STT but no rewrite shows missing rewrite")
+    func aggressiveModeMissingRewrite() {
+        let snapshot = StatusBarMenuSnapshot.make(
+            state: .idle(processingLevel: .aggressive),
+            hasCloudSTT: true,
+            hasRewrite: false
+        )
+
+        #expect(snapshot.cloudTitle == "Cloud STT ready; rewrite not configured")
+        #expect(snapshot.cloudNeedsAction == true)
     }
 }


### PR DESCRIPTION
Closes #186

## Problem
Status messaging implied "API keys missing" even when Apple Speech/local path was fully valid. Users received misleading failure signals during setup.

## Solution
Introduce \"CloudStatus\" enum that calculates readiness based on processing level and available providers.

### Changes

**StatusBarController.swift:**
- New \"CloudStatus.forLevel()\" method returns appropriate status message and actionability
- **Off mode:** Only transcription matters (rewrite not used)
  - No cloud STT → \"On-device transcription\" (not an error!)
  - Has cloud STT → \"Cloud transcription ready\"
- **Light/Aggressive/Enhance modes:** Require rewrite
  - Full config → \"Cloud services: Ready\"
  - Missing rewrite → \"Cloud STT ready; rewrite not configured\" (actionable)
  - No cloud at all → \"Cloud services not configured; limited to Off mode\" (actionable)

### Before/After Examples

| Mode | Cloud STT | Rewrite | Before | After |
|------|-----------|---------|--------|-------|
| Off | No | No | \"Cloud services: Not configured\" ❌ | \"On-device transcription\" ✓ |
| Light | No | No | \"Cloud services: Not configured\" ❌ | \"Cloud services not configured; limited to Off mode\" ✓ |
| Light | Yes | No | \"Cloud STT ready; rewrite missing\" | \"Cloud STT ready; rewrite not configured\" |

### Testing
- Updated StatusBarMenuSnapshotTests with 8 test cases covering all combinations
- Status messaging now aligns with OnboardingChecklistView (which already showed \"On-device only\")

## Checklist
- [x] Implementation follows TDD pattern
- [x] All tests updated
- [x] Commit follows conventional format (feat:)
- [x] Closes linked issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Refined status messages to more clearly indicate cloud service readiness and configuration states.
  * Improved accuracy of action prompts for various combinations of processing modes and cloud service availability.

* **Tests**
  * Expanded test coverage for cloud service integration across different processing modes and configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->