### PR TITLE
feat(hud): liquid glass aesthetic refinements

### DIFF
--- a/Sources/VoxMac/HUDView.swift
+++ b/Sources/VoxMac/HUDView.swift
@@ -99,8 +99,8 @@ public final class HUDState: ObservableObject {
 // MARK: - Design System
 
 enum HUDLayout {
-    static let expandedWidth: CGFloat = 170
-    static let expandedHeight: CGFloat = 40
+    static let expandedWidth: CGFloat = 160
+    static let expandedHeight: CGFloat = 36
 }
 
 private enum Design {
@@ -122,8 +122,8 @@ private enum Design {
     static let shadowY: CGFloat = 3
 
     // Typography
-    static let timerFont = Font.system(size: 12, weight: .medium, design: .monospaced)
-    static let labelFont = Font.system(size: 12, weight: .medium)
+    static let timerFont = Font.system(size: 11, weight: .medium, design: .monospaced)
+    static let labelFont = Font.system(size: 11, weight: .medium)
     static let textSecondary = Color.white.opacity(0.55)
 }
 
@@ -286,12 +286,12 @@ public struct HUDView: View {
     public var body: some View {
         HStack(spacing: 6) {
             iconZone
-                .frame(width: 28, height: 28)
+                .frame(width: 24, height: 24)
             Spacer()
             textZone
         }
         .padding(.leading, 10)
-        .padding(.trailing, 12)
+        .padding(.trailing, 11)
         .frame(width: Design.width, height: Design.height)
         .background(containerBackground)
         .clipShape(Capsule())


### PR DESCRIPTION
## Summary

Iterative UI polish on the HUD toward Apple's liquid glass design language. Each commit is an incremental visual change for easy review.

## Changes

- [x] **Capsule shape** — `RoundedRectangle(cornerRadius: 12)` → `Capsule()` for uniform curvature
- [ ] **Icon glow per state** — soft radial glow behind state icons (red/blue/green)
- [ ] **Top-edge specular highlight** — white gradient simulating glass light source
- [ ] **Size tuning** — tighten from 170×40 toward ~160×36

## Test plan

- [ ] Build with warnings-as-errors: `swift build -Xswiftc -warnings-as-errors`
- [ ] Visual inspection of all four HUD states (idle, recording, processing, success)
- [ ] Verify capsule renders as one clean shape with no corner/edge discontinuity
- [ ] Check reduced motion path still works
- [ ] Run test suite: `swift test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Visual Improvements**
  * HUD recording indicator layout refined with more compact, optimized spacing.
  * Enhanced container styling with improved visual shapes and edge highlights.
  * Adjusted typography for improved clarity and readability.
  * State-specific visual enhancements: Recording, processing, and completion states now feature subtle background accents for better visual feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->