### PR TITLE
docs: document Landfall automated release workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,25 @@ cp .env.example .env.local  # Add your keys
 
 ## Release (Maintainers)
 
-Build signed + notarized distribution artifacts:
+Vox uses [Landfall](https://github.com/misty-step/landfall) — Misty Step's automated release pipeline — for versioning, changelog generation, and release notes.
+
+### Automated Releases (CI)
+
+The release workflow triggers automatically when CI passes on the `master` branch:
+
+1. Merge PRs to `master` with conventional commit messages (`feat:`, `fix:`, etc.)
+2. Landfall analyzes commits since the last tag
+3. Determines version bump (major/minor/patch) from commit types
+4. Generates changelog entries and release notes
+5. Creates GitHub release with automatically generated notes
+
+**Workflow file:** `.github/workflows/release.yml`
+
+**Manual trigger:** Maintainers can also trigger releases via `workflow_dispatch` in the Actions tab.
+
+### Local Release (Signing + Notarization)
+
+For signed + notarized `Vox.app` distribution artifacts (macOS Gatekeeper compliant):
 
 ```bash
 export VOX_SIGNING_IDENTITY="Developer ID Application: Your Name (TEAMID)"
@@ -49,7 +67,11 @@ export VOX_NOTARY_PROFILE="vox-notary"
 ./scripts/release-macos.sh
 ```
 
-Full release setup and CI secrets are documented in `docs/RELEASE.md`.
+Outputs:
+- `dist/Vox.app` — signed, notarized app bundle
+- `dist/Vox-macos.zip` — stapled zip for distribution
+
+Full release setup, certificate configuration, and CI secrets are documented in `docs/RELEASE.md`.
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,9 @@ export VOX_NOTARY_PROFILE="vox-notary"
 ./scripts/release-macos.sh
 ```
 
-See `docs/RELEASE.md` for full setup (certificate, notary credentials, CI secrets).
+**Automated Releases:** Vox uses [Landfall](https://github.com/misty-step/landfall) for automated versioning and releases. When PRs merge to `master` with conventional commits (`feat:`, `fix:`, etc.), Landfall automatically bumps the version, updates the changelog, and creates GitHub releases.
+
+See `docs/RELEASE.md` for full setup (certificate, notary credentials, CI secrets) and `CONTRIBUTING.md` for release workflow details.
 
 ### Configuration
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,6 +1,40 @@
-# Release Guide (macOS, Signed + Notarized)
+# Release Guide
 
-This repository ships a release script that builds a distributable `Vox.app`, signs it, notarizes it, staples the ticket, and verifies Gatekeeper.
+Vox has two release paths:
+1. **Landfall (Automated)** — Versioning, changelog, and GitHub releases via CI
+2. **macOS Signing (Manual/CI)** — Signed + notarized app bundle distribution
+
+---
+
+## Landfall Automated Releases
+
+Vox uses [Landfall](https://github.com/misty-step/landfall) — Misty Step's GitHub Action for automated versioning, changelog generation, and release notes.
+
+### How It Works
+
+1. **Conventional Commits:** Use `feat:`, `fix:`, `refactor:`, `docs:` prefixes in commit messages
+2. **Automatic Versioning:** Landfall analyzes commits and determines semver bump (major/minor/patch)
+3. **Changelog Generation:** Updates `CHANGELOG.md` with categorized entries
+4. **GitHub Release:** Creates release with auto-generated notes
+
+### Triggers
+
+- **Automatic:** On every successful CI run on `master` branch (after PR merge)
+- **Manual:** `workflow_dispatch` in GitHub Actions UI
+
+### Workflow
+
+- **File:** `.github/workflows/release.yml`
+- **Action:** `misty-step/landfall@v1`
+- **Required secrets:**
+  - `GH_RELEASE_TOKEN` — GitHub token with release permissions
+  - `MOONSHOT_API_KEY` — LLM API key for release note generation
+
+---
+
+## macOS Signed + Notarized Distribution
+
+For distributing a Gatekeeper-compliant `Vox.app` that users can run without security warnings.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary
Documents the Landfall GitHub Action integration for automated releases.

## Changes
- **CONTRIBUTING.md**: Added comprehensive "Release (Maintainers)" section explaining:
  - Automated Landfall CI releases (triggers, version bumping, changelog generation)
  - Local signed/notarized releases for macOS distribution
  
- **README.md**: Updated "Signed Distribution" section with Landfall mention and cross-references

- **docs/RELEASE.md**: Restructured to document Landfall first, then macOS signing details

## Acceptance Criteria
- [x] Landfall workflow documented in CI
- [x] Version/changelog/release-note process explained
- [x] README/docs updated with release workflow expectations
- [x] Cross-references between docs added

## Issue
Closes #211