### PR TITLE
docs: sync changelog with latest v1.17.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.17.0](https://github.com/misty-step/vox/compare/v1.16.0...v1.17.0) (2026-02-17)
+
+
+### Features
+
+* **observability:** export diagnostics bundle ([#262](https://github.com/misty-step/vox/issues/262)) ([a6821c6](https://github.com/misty-step/vox/commit/a6821c63362cb6d0c2e32247ef2a275e9e9ceda5)), closes [#180](https://github.com/misty-step/vox/issues/180)
+
 # [1.16.0](https://github.com/misty-step/vox/compare/v1.15.0...v1.16.0) (2026-02-16)
 
 


### PR DESCRIPTION
Closes #263

## Summary
- Documented the existing v1.17.0 release in CHANGELOG.md to satisfy the dependency-pinning release record requirement.

## Notes
- Release  already exists on  and points to the current packaged release.
- This change has no runtime behavior impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CHANGELOG for version 1.17.0
  
* **New Features**
  * Export diagnostics bundle for improved observability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->