### PR TITLE
feat(streaming): session-level finalize timeout + non-streaming recorder test

### DIFF
--- a/Sources/VoxAppKit/VoxSession.swift
+++ b/Sources/VoxAppKit/VoxSession.swift
@@ -1106,6 +1106,9 @@ private func withStreamingFinalizeTimeout<T: Sendable>(
     // the hung operation and return control to the caller immediately on timeout.
     return try await withCheckedThrowingContinuation { continuation in
         let state = _FinalizeOnceState(continuation)
+        // operationTask may outlive the continuation if operation() is non-cooperative.
+        // The caller's fallback path calls bridge.cancel(), which tears down the
+        // underlying WebSocket and unblocks the hung operation eventually.
         let operationTask = Task {
             do {
                 state.resume(with: .success(try await operation()))

--- a/Tests/VoxAppTests/VoxSessionTests.swift
+++ b/Tests/VoxAppTests/VoxSessionTests.swift
@@ -795,7 +795,7 @@ struct VoxSessionDITests {
     }
 
     @Test("Streaming finalize timeout unblocks when operation cannot be cancelled")
-    @MainActor func test_streamingFinalizeTimeout_unblockesNonCooperativeOperation() async {
+    @MainActor func test_streamingFinalizeTimeout_unblocksNonCooperativeOperation() async {
         // Verifies that withStreamingFinalizeTimeout uses unstructured Tasks (not
         // withThrowingTaskGroup) so the caller is unblocked even when bridge.finish()
         // ignores task cancellation (e.g. blocked in synchronous C/WebSocket I/O).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -88,7 +88,7 @@ Error classification is centralized in `STTError.isRetryable`, `STTError.isFallb
 3) `VoxSession` applies selected input as system default (compatibility path), then `AudioRecorder` starts capture
 4) `AudioRecorder` records 16kHz/16-bit mono CAF via `AVAudioEngine` (default backend) and emits PCM chunks when available
 5) If streaming STT is available (ElevenLabs preferred; Deepgram fallback) and not disabled (`VOX_DISABLE_STREAMING_STT`), `VoxSession` forwards PCM chunks to a `StreamingSTTSession`
-6) On stop, `VoxSession` attempts streaming `finish()` with bounded timeout (scaled by streamed audio duration, capped)
+6) On stop, `VoxSession` attempts streaming `finish()` with two-layer timeout: provider-level (scaled by streamed audio duration, recovers partial transcripts) and session-level safety net (90s default, catches transport-level hangs like stuck WebSocket drains)
 7) If streaming is unavailable, setup fails, or finalize fails/times out, fallback to batch STT router (default sequential; opt-in `VOX_STT_ROUTING=hedged`)
 8) Transcript → rewrite (Gemini, fallback OpenRouter) when `ProcessingLevel` = clean/polish
 9) `RewriteQualityGate` scores rewrite similarity (benchmarks/debug)


### PR DESCRIPTION
## Summary

Closes #258

Adds a session-level safety net for the streaming finalize path. Before this PR, a hung `bridge.finish()` call could stall a VoxSession indefinitely — the provider-level `TimeoutSTTProvider` is the first line of defense, but if the streaming bridge's drain loop never returned, the session would hang. This PR adds `streamingFinalizeTimeout` (default 90s) wrapping `bridge.finish()` at the session layer, giving a bounded worst-case no matter what the provider does.

Also adds a `MockNonStreamingRecorder` test to verify the acceptance criterion: when the audio recorder doesn't support `AudioChunkStreaming`, Vox skips streaming entirely and falls through to the batch path — confirming "streaming used when possible, batch only as safety net."

## Changes

- **`Sources/VoxAppKit/VoxSession.swift`**
  - New `streamingFinalizeTimeout: TimeInterval = 90.0` parameter on both `init` overloads
  - `bridge.finish()` is now wrapped in `withStreamingFinalizeTimeout(seconds:)` — throws `StreamingSTTError.finalizationTimeout` on breach, which falls back to the batch chain
  - New `withStreamingFinalizeTimeout` private free function, mirroring the existing `withStreamingSetupTimeout` pattern (uses `withThrowingTaskGroup` race, reuses `validatedStreamingTimeoutNanoseconds`)

- **`Tests/VoxAppTests/VoxSessionTests.swift`**
  - `MockNonStreamingRecorder`: minimal `AudioRecording`-only mock (no `AudioChunkStreaming` conformance)
  - `test_nonStreamingRecorder_skipsStreamingAndUsesBatchPath`: verifies streaming is never attempted when recorder doesn't support chunking
  - Extended `MockStreamingSession` with `finishDelay` to simulate a slow provider
  - `test_streamingFinalizeTimeout_enforcedAtSessionLevel`: 0.1s timeout, 5s simulated delay → session completes via fallback in < 2s

## Acceptance Criteria

From #258:
- [x] When streaming provider keys exist and audio backend supports chunking, Vox uses streaming by default *(existing behavior, protected by new non-streaming test)*
- [x] Batch path remains as a safety net and is exercised by tests — `test_nonStreamingRecorder_skipsStreamingAndUsesBatchPath`
- [x] Streaming success path logs one concise timing summary + failure reason on fallback (no transcript) *(existing instrumentation, no change)*

Specific to this PR:
- [x] A hung `bridge.finish()` no longer stalls the session indefinitely (90s session-level cap)
- [x] Finalize timeout falls back to batch rather than surfacing as an error to the user

## Manual QA

```bash
# 1. Build
swift build -Xswiftc -warnings-as-errors

# 2. Run the new tests
swift test --filter VoxSessionTests 2>&1 | tail -20

# 3. Run full audio guardrails to confirm no regressions
./scripts/test-audio-guardrails.sh

# 4. Run full suite
./scripts/run-tests-ci.sh
```

Expected: all tests pass, no new warnings.

To exercise the timeout path manually:
- Set `streamingFinalizeTimeout: 0.1` in a local debug session
- Record a short clip with Deepgram key present
- Observe fallback to batch path in logs (`[STT] streaming finalize timeout, falling back to batch`)

## Before / After

**Before:** `bridge.finish()` was called bare — if the streaming provider's drain loop hung (network partition, provider bug), the session would stall forever with no bound.

```swift
// Before — no timeout
let transcript = try await bridge.finish()
```

**After:** `bridge.finish()` races against a 90s session-level timer. On breach, `StreamingSTTError.finalizationTimeout` is thrown and the session falls back to the batch chain cleanly.

```swift
// After — bounded at session level
let transcript = try await withStreamingFinalizeTimeout(seconds: streamingFinalizeTimeout) {
    try await bridge.finish()
}
```

## Test Coverage

| File | Test |
|------|------|
| `Tests/VoxAppTests/VoxSessionTests.swift` | `test_nonStreamingRecorder_skipsStreamingAndUsesBatchPath` — verifies batch fallback when recorder lacks streaming |
| `Tests/VoxAppTests/VoxSessionTests.swift` | `test_streamingFinalizeTimeout_enforcedAtSessionLevel` — verifies 0.1s timeout triggers fallback within 2s |

**Gaps:** Integration test with a real provider hang is not feasible in the unit suite. The 90s default is conservatively large — the intent is catching catastrophic hangs, not normal slowness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable timeout for streaming speech-to-text finalization (default: 90 seconds).
  * Exceeding the timeout returns an error instead of indefinite waiting.

* **Tests**
  * Enhanced test coverage for streaming finalization timeout behavior and non-streaming recorder scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Polish Pass

**Before:** Working implementation with a typo in test naming (`unblockesNonCooperativeOperation`), no documentation of the orphaned task lifecycle in the timeout mechanism, and architecture docs describing only the provider-level timeout.

**After:**
- Fixed test method name typo
- Added comment documenting that orphaned `operationTask` is bounded by `bridge.cancel()` on the fallback path (future readers won't need to trace the lifecycle themselves)
- Updated `ARCHITECTURE.md` step 6 to document the two-layer timeout: provider-level (scaled by audio duration, recovers partial transcripts) + session-level safety net (90s, catches transport-level hangs)

**Hindsight review confirmed:** Unstructured Tasks (vs TaskGroup) is the correct approach for non-cooperative I/O. The asymmetry with `withStreamingSetupTimeout` (which uses TaskGroup) is intentional — setup calls cooperative Swift code, finalize may block on WebSocket I/O. No architectural changes needed.