### PR TITLE
feat(rewrite): route clean dictation through Apple Foundation Models (#256)

### DIFF
--- a/Sources/VoxProviders/AppleFoundationModelsClient.swift
+++ b/Sources/VoxProviders/AppleFoundationModelsClient.swift
@@ -34,7 +34,7 @@ public final class AppleFoundationModelsClient: RewriteProvider {
         }
     }
 
-    private func mapGenerationError(_ error: LanguageModelSession.GenerationError) -> RewriteError {
+    func mapGenerationError(_ error: LanguageModelSession.GenerationError) -> RewriteError {
         switch error {
         case .rateLimited:
             return .throttled


### PR DESCRIPTION
## What
- Split rewrite routing so `.clean` and `.polish` no longer share the same provider path.
- In `DictationPipeline`, introduced a dedicated `cleanRewriter` path and routed `.clean` stages to it.
- In `VoxSession`, wired:
  - `rewriter` = existing cloud rewrite chain (Gemini/OpenRouter)
  - `cleanRewriter` = `AppleFoundationModelsClient` first on macOS 26+ (availability-gated), with cloud fallback via `FallbackRewriteProvider`.
- Restored missing-key warning behavior for cloud-only rewrite composition in cloud path.
- Made `AppleFoundationModelsClient.mapGenerationError(_:)` test-visible and added full error mapping coverage.
- Added pipeline tests for clean routing/fallback/cancellation and a clean-vs-polish behavior test.

## Why
Issue #256 requested a fast-path evaluation for Apple Foundation Models as the clean rewrite default with cloud fallback and no new settings.

## How
- Kept architecture-level composition via existing `FallbackRewriteProvider` rather than introducing branching in providers.
- Preserved default behavior for `.polish`; only clean path now attempts Foundation Models first.
- Kept API/key fallback behavior and warning semantics intact.

## Validation
- `swift build -Xswiftc -warnings-as-errors`
- `swift test -Xswiftc -warnings-as-errors` (239 tests)
- `./scripts/benchmark.sh`

## Notes
Acceptance gate metrics for issue decision (p50/p95 + `RewriteQualityGate` accept rate) were not collected in this environment because FoundationModels-backed runtime is unavailable here. Decision (adopt/defer) still depends on those external benchmark values.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new clean processing pathway supporting on-device rewriting with automatic cloud fallback.
  * Extended the rewriting pipeline to intelligently route requests based on processing level requirements.
  * Enhanced configuration validation with clearer warnings for missing API keys.

* **Tests**
  * Added comprehensive test coverage for clean processing paths, cloud fallback scenarios, and cancellation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->